### PR TITLE
Add callback classes handling

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+/**
+ * Dataflows Manager
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class manager {
+
+    /**
+     * Return all dataflow steps available from other plugins and by default
+     *
+     * This is defined in lib.php for each plugin, and returned via a dataflow_steps function
+     *
+     * @return array of step objects
+     */
+    public static function get_steps(): array {
+        $steps = [
+            new step\debugging()
+        ];
+        $moresteps = get_plugins_with_function('dataflow_steps', 'lib.php');
+        foreach ($moresteps as $plugintype => $plugins) {
+            foreach ($plugins as $plugin => $pluginfunction) {
+                $result = $pluginfunction();
+                foreach ($result as $step) {
+                    $step->set_component($plugintype . '_' . $plugin);
+                    $steps[] = $step;
+                }
+            }
+        }
+        return $steps;
+    }
+}

--- a/classes/step/debugging.php
+++ b/classes/step/debugging.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\step;
+
+/**
+ * Dataflows Manager
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class debugging extends \tool_dataflows\step\step {
+
+    /**
+     * Executes the step
+     *
+     * This will logs the input via debugging and passes the input value as-is to the output.
+     *
+     * @param mixed $input
+     * @return mixed $output
+     */
+    public function execute($input) {
+        $output = $input;
+        debugging(json_encode($input));
+        return $output;
+    }
+}

--- a/classes/step/step.php
+++ b/classes/step/step.php
@@ -1,0 +1,101 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\step;
+
+/**
+ * Base class for steps
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class step {
+
+    /**
+     * @var string $component - The component / plugin this step belongs to.
+     *
+     * This is autopopulated by the dataflows manager.
+     */
+    protected $component = 'tool_dataflows';
+
+    /**
+     * Get the frankenstyle component name
+     *
+     * @return string
+     */
+    public function get_component(): string {
+        return $this->component;
+    }
+
+    /**
+     * Get the frankenstyle component name
+     *
+     * @param string $component name
+     */
+    public function set_component(string $component) {
+        $this->component = $component;
+    }
+
+    /**
+     * Get the step's id
+     *
+     * This defaults to the base name of the class which is ok in the most
+     * cases but if you have a step which can have multiple instances then
+     * you should override this to be unique.
+     *
+     * @return string must be unique within a component
+     */
+    public function get_id(): string {
+        $class = get_class($this);
+        $id = explode("\\", $class);
+        return end($id);
+    }
+
+    /**
+     * Get the step reference
+     *
+     * @return string must be globally unique
+     */
+    public function get_ref(): string {
+        $ref = $this->get_component();
+        if (!empty($ref)) {
+            $ref .= '_';
+        }
+        $ref .= $this->get_id();
+        return $ref;
+    }
+
+    /**
+     * Get the short step name
+     *
+     * @return string
+     */
+    public function get_name(): string {
+        $id = $this->get_id();
+        return get_string("step{$id}", $this->get_component());
+    }
+
+    /**
+     * Step callback handler
+     *
+     * Implementation can vary, this might be a transformer, resource, or
+     * something else.
+     */
+    abstract public function execute($input);
+}
+

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+/**
+ * Units tests for the manager class.
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_test extends \advanced_testcase {
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * @covers \tool_dataflows\step\debugging
+     */
+    public function test_debugging_step(): void {
+        $step = new step\debugging();
+        $input = [1, 2, 3, 4, 5];
+        $output = $step->execute($input);
+
+        // No changes are expected.
+        $this->assertEquals($input, $output);
+
+        // Debugging was called with the expected format.
+        $this->assertDebuggingCalled(json_encode($input));
+    }
+}


### PR DESCRIPTION
This only populates the list of available steps supplied by other plugins.

Currently I have added an example one which only ingests some data and outputs the same data, whilst doing a side effect of passing it to debugging in json format.

Related to #20