### PR TITLE
add optional test for custom step - tested via CI, using a custom local_aws branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,4 @@ jobs:
     with:
       disable_behat: true
       disable_grunt: true
+      extra_plugin_runners: 'moodle-plugin-ci add-plugin catalyst/moodle-local_aws --branch ci-for-tool_dataflows'

--- a/lib.php
+++ b/lib.php
@@ -31,7 +31,7 @@ function tool_dataflows_after_config() {
 /**
  * Returns a list of step types available for this plugin.
  *
- * NOTE: For other plugins, the function name should be simply declared as dataflow_step_types.
+ * NOTE: For other plugins, the function name should be simply declared as <component_name>_dataflow_step_types.
  *
  * @return     array of step types
  */

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -16,8 +16,13 @@
 
 namespace tool_dataflows;
 
+defined('MOODLE_INTERNAL') || die();
+
+// Include lib.php functions that aren't included automatically for Moodle 37- and below.
+require_once(dirname(__FILE__) . '/../lib.php');
+
 /**
- * Units tests for the manager class.
+ * Units tests for tool_dataflows
  *
  * @package    tool_dataflows
  * @author     Kevin Pham <kevinpham@catalyst-au.net>
@@ -151,6 +156,26 @@ class tool_dataflows_test extends \advanced_testcase {
         $stepone->depends_on([$stepthree])->upsert();
         $validation = $dataflow->validate_dataflow();
         $this->assertNotTrue($validation);
+    }
+
+    /**
+     * Test custom step type based on the callback defined in the manager.
+     *
+     * @covers \tool_dataflows\dataflow\manager::get_steps_types
+     */
+    public function test_local_aws_custom_step() {
+        // The test should only run if this condition is true.
+        $localawsexampleclass = class_exists(\local_aws\step\example::class);
+        if (!$localawsexampleclass) {
+            $this->markTestSkipped('local_aws with custom step not located, skipping this specific test.');
+            return;
+        }
+
+        $steptypes = manager::get_steps_types();
+        $classnames = array_map(function ($class) {
+            return get_class($class);
+        }, $steptypes);
+        $this->assertContains(\local_aws\step\example::class, $classnames);
     }
 
     /**


### PR DESCRIPTION
- test: add test for example local_aws and available custom steps

This would ideally be merged after PR #66 

Added https://github.com/catalyst/moodle-local_aws/tree/ci-for-tool_dataflows with an example step type to test out this functionality. This would also be a good candidate to add to the README.

Resolves #20 