### PR TITLE
Basic execution 2

### DIFF
--- a/classes/execution/connector_engine_step.php
+++ b/classes/execution/connector_engine_step.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution;
+
+/**
+ * Engine step for connectors.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class connector_engine_step extends engine_step {
+
+    /**
+     * True for flow steps, false for connector steps.
+     *
+     * @return bool
+     */
+    public function is_flow(): bool {
+        return false;
+    }
+
+    /**
+     * Attempt to execute the step.
+     *
+     * @return int
+     */
+    public function go(): int {
+        switch ($this->proceed_status()) {
+            case self::PROCEED_GO:
+                try {
+                    $result = $this->steptype->do_task();
+                    if ($result) {
+                        $this->status = engine::STATUS_FINISHED;
+                    } else {
+                        $this->status = engine::STATUS_CANCELLED;
+                    }
+                } catch (\Throwable $thrown) {
+                    $this->status = engine::STATUS_ABORTED;
+                    $this->exception = $thrown;
+                }
+                break;
+            case self::PROCEED_STOP:
+                $this->status = engine::STATUS_CANCELLED;
+                break;
+            case self::PROCEED_WAIT:
+                $this->status = engine::STATUS_BLOCKED;
+                break;
+        }
+        return $this->status;
+    }
+}

--- a/classes/execution/engine.php
+++ b/classes/execution/engine.php
@@ -1,0 +1,207 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution;
+
+use tool_dataflows\dataflow;
+
+/**
+ * Executes a dataflow
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class engine {
+
+    /**
+     * Defines the execution status used by the engine and the engine steps.
+     */
+    /** @var int Just created. */
+    const STATUS_NEW = 0;
+    /** @var int Initialised. Ready to run. */
+    const STATUS_INITIALISED = 1;
+    /** @var int Connector cannot proceed, waiting on upstreams. */
+    const STATUS_BLOCKED = 2;
+    /** @var int Flow cannot proceed, waiting on upstreams. */
+    const STATUS_WAITING = 3;
+    /** @var int Connector is currently processing. */
+    const STATUS_PROCESSING = 4;
+    /** @var int Flow is currently active */
+    const STATUS_FLOWING = 5;
+    /** @var int Step has finished activity. Downstreams can proceed. */
+    const STATUS_FINISHED = 6;
+    /** @var int Step has been cancelled. Downstreams may also be cancelled. */
+    const STATUS_CANCELLED = 7;
+    /** @var int The dataflow execution has been aborted. Not able to finish */
+    const STATUS_ABORTED = 8;
+    /** @var int Step/dataflow has completely finished. */
+    const STATUS_FINALISED = 9;
+
+    /** @var  array The queue of steps to be given a run. */
+    protected $queue;
+
+    /** @var dataflow The dataflow defined by the user. */
+    protected $dataflow;
+
+    /** @var array The engine steps in the dataflow. */
+    protected $enginesteps = [];
+
+    /** @var array The steps that have no outputstreams. */
+    protected $sinks = [];
+
+    /** @var int The status of the execution. */
+    protected $status = self::STATUS_NEW;
+
+    /**
+     * Constructs the engine.
+     *
+     * @param dataflow $dataflow The dataflow to be executed, as defined in the editor.
+     */
+    function __construct(dataflow $dataflow) {
+        $this->dataflow = $dataflow;
+
+       // Create engine steps for each step in the dataflow.
+        foreach ($dataflow->steps() as $stepdef) {
+            $classname = $stepdef->type;
+            $steptype = new $classname();
+            $this->enginesteps[$stepdef->id] = $steptype->get_engine_step($this, $stepdef);
+        }
+
+        // Create the links between step executors.
+        foreach ($this->enginesteps as $id => $enginestep) {
+            $deps = $enginestep->stepdef->dependencies();
+            foreach ($deps as $dep) {
+                $depstep = $this->enginesteps[$dep->id];
+                $enginestep->upstreams[$dep->id] = $depstep;
+                $depstep->downstreams[$id] = $enginestep;
+            }
+        }
+
+        // Find the sinks.
+        foreach ($this->enginesteps as $enginestep) {
+            if (count($enginestep->downstreams) == 0) {
+                $this->sinks[] = $enginestep;
+            }
+        }
+
+        // Find the flow blocks
+        $this->create_flow_caps();
+    }
+
+    public function initialise() {
+        foreach ($this->enginesteps as $enginestep) {
+            $enginestep->initialise();
+        }
+
+        // Add sinks to the execution queue.
+        $this->queue = $this->sinks;
+        $this->status = self::STATUS_INITIALISED;
+    }
+
+    /**
+     * Finds the steps that are sinks for their respective flow blocks and create flow caps for them.
+     */
+    protected function create_flow_caps() {
+    }
+
+    /**
+     * Runs the data flow as a single action. This function initialises the dataflow,
+     * runs the dataflow, and finalises it.
+     */
+    public function execute() {
+        $this->initialise();
+        while ($this->status != self::STATUS_FINISHED) {
+            $this->execute_step();
+            if ($this->status == self::STATUS_ABORTED) {
+                return;
+            }
+        }
+        $this->finalise();
+    }
+
+    /**
+     * Executes a single step. Must be initialised prior to calling.
+     */
+    public function execute_step() {
+        if ($this->status == self::STATUS_INITIALISED) {
+            $this->status = self::STATUS_PROCESSING;
+        }
+        if ($this->status != self::STATUS_PROCESSING) {
+            throw new \moodle_exception("bad_status", "tool_dataflows");
+        }
+        if (count($this->queue)) {
+            $this->status = self::STATUS_FINISHED;
+        } else {
+            $currentstep = array_shift($this->queue);
+            $result = $currentstep->go();
+
+            switch ($result['status']) {
+                case self::STATUS_BLOCKED:
+                case self::STATUS_WAITING:
+                    foreach ($currentstep->upstreams as $upstream) {
+                        $this->queue[] = $upstream;
+                    }
+                    break;
+                case self::STATUS_FINISHED:
+                case self::STATUS_CANCELLED:
+                    foreach ($currentstep->downstreams as $downstream) {
+                        $this->queue[] = $downstream;
+                    }
+                    break;
+                case self::STATUS_FLOWING:
+                    foreach ($currentstep->downstreams as $downstream) {
+                        if ($downstream->is_flow()) {
+                            $this->queue[] = $downstream;
+                        }
+                    }
+                    break;
+                case self::STATUS_ABORTED:
+                    $this->abort();
+            }
+        }
+    }
+
+    /**
+     * Finalises the execution. Any remaining resources should be released.
+     */
+    public function finalise() {
+        foreach ($this->enginesteps as $enginestep) {
+            $enginestep->finalise();
+        }
+        $this->status = self::STATUS_FINALISED;
+    }
+
+    /**
+     * Stops execution immediately. Gracefully stops all processors and iterators.
+     */
+    public function abort() {
+        foreach ($this->enginesteps as $enginestep) {
+            $enginestep->abort();
+        }
+        $this->status = self::STATUS_ABORTED;
+    }
+
+    public function __get($p) {
+        switch ($p) {
+            case 'status':
+                return $this->status;
+            default:
+                throw new \moodle_exception('');
+        }
+    }
+}

--- a/classes/execution/engine_step.php
+++ b/classes/execution/engine_step.php
@@ -1,0 +1,94 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution;
+
+use tool_dataflows\step\base_step;
+use tool_dataflows\step;
+
+/**
+ * Manages the execution of a step
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class engine_step {
+
+    /** @var engine Dataflow_execution engine  */
+    protected $engine;
+
+    /** @var int ID as supplied by the step definition */
+    protected $id;
+
+    /** @var step Step definition provided by the editor */
+    protected $stepdef;
+
+    /** @var base_step The step type definition. */
+    protected $steptype;
+
+    /** @var array  The upstream steps. */
+    public $upstreams = [];
+
+    /** @var array  The downstream steps. */
+    public $downstreams = [];
+
+    /** @var int The step's current status */
+    protected $status = engine::STATUS_NEW;
+
+    public function __construct(engine $engine, step $stepdef, base_step $steptype) {
+        $this->engine = $engine;
+        $this->stepdef = $stepdef;
+        $this->steptype = $steptype;
+        $this->id = $stepdef->id;
+    }
+
+    /**
+     * Initialises the step.
+     */
+    public function initialise() {
+        $this->status = engine::STATUS_INITIALISED;
+    }
+
+    /**
+     * Finalises the step.
+     */
+    public function finalise() {
+        $this->status = engine::STATUS_FINALISED;
+    }
+
+    /**
+     * Exposes parameters that need to be accessed.
+     *
+     * @param $parameter
+     * @return mixed
+     * @throws \moodle_exception
+     */
+    public function __get($parameter) {
+        switch ($parameter) {
+            case 'id':
+            case 'status':
+            case 'stepdef':
+                return $this->$parameter;
+            case 'name':
+                return $this->stepdef->name;
+            default:
+                throw new \moodle_exception('Parameter ' . $parameter . ' not defined.');
+        }
+    }
+
+}

--- a/classes/execution/flow_engine_step.php
+++ b/classes/execution/flow_engine_step.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution;
+
+use tool_dataflows\step\base_step;
+use tool_dataflows\step;
+
+/**
+ * Manages the execution of a flow step.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class flow_engine_step extends engine_step {
+
+    /** @var iterator The iterator for this step. */
+    protected $iterator = null;
+
+    /**
+     * True for flow steps, false for connector steps.
+     *
+     * @return bool
+     */
+    public function is_flow(): bool {
+        return true;
+    }
+
+    /**
+     * Aborts the step.
+     */
+    public function abort() {
+        if (!is_null($this->iterator)) {
+            $this->iterator->abort();
+        }
+    }
+
+    /**
+     * Attempt to execute the step.
+     *
+     * @return int
+     */
+    public function go(): int {
+        switch ($this->proceed_status()) {
+            case self::PROCEED_GO:
+                try {
+                    $this->iterator = $this->steptype->get_iterator($this);
+                    $this->status = engine::STATUS_FLOWING;
+                } catch (\Throwable $thrown) {
+                    $this->status = engine::STATUS_ABORTED;
+                    $this->exception = $thrown;
+                }
+                break;
+            case self::PROCEED_STOP:
+                $this->status = engine::STATUS_CANCELLED;
+                break;
+            case self::PROCEED_WAIT:
+                $this->status = engine::STATUS_WAITING;
+                break;
+        }
+        return $this->status;
+    }
+}

--- a/classes/execution/iterators/iterator.php
+++ b/classes/execution/iterators/iterator.php
@@ -1,0 +1,54 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution\iterators;
+
+/**
+ * Iterator interface for use within a dataflow structure.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+interface iterator {
+    /**
+     * True if the iterator has no more values to provide.
+     *
+     * @return bool
+     */
+    public function is_finished(): bool;
+
+    /**
+     * True if the iterator is capable (or allowed) of supplying a value.
+     *
+     * @return bool
+     */
+    public function is_ready(): bool;
+
+    /**
+     * Terminate the iterator immediately.
+     */
+    public function abort();
+
+    /**
+     * Next item in the stream.
+     *
+     * @return object|bool A JSON compatible object, or false if nothing returned.
+     */
+    public function next();
+}

--- a/classes/execution/iterators/map_iterator.php
+++ b/classes/execution/iterators/map_iterator.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution\iterators;
+
+use tool_dataflows\execution\step_executor;
+
+/**
+ * A mapping iterator that takes in a value from another iterator, passes it to a function, and then
+ * passes the return value to the output.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class map_iterator implements iterator {
+    private $steptype;
+    private $finished = false;
+    private $input;
+
+    public function __construct(step_executor $step, iterator $input) {
+        $this->step = $step;
+        $this->input = $input;
+        $this->steptype = $step->steptype;
+    }
+
+    public function is_finished(): bool {
+        return $this->finished;
+    }
+
+    public function is_ready(): bool {
+        return !$this->finished && $this->input->is_ready();
+    }
+
+    public function abort() {
+        $this->finished = true;
+    }
+
+    public function next() {
+        if ($this->finished) {
+            return false;
+        }
+        try {
+            $value = $this->input->next();
+            if ($this->input->is_finished()) {
+                $this->abort();
+                $this->step->iterator_finished();
+            }
+            $newvalue = $this->steptype->execute($value);
+            return $newvalue;
+        } catch (\Throwable $exception) {
+            $this->step->dataflow->abort($this->step, $exception);
+        }
+    }
+}

--- a/classes/execution/iterators/php_iterator.php
+++ b/classes/execution/iterators/php_iterator.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\executor\iterators;
+
+use tool_dataflows\executor\step_executor;
+
+/**
+ * A mapping iterator that takes a PHP iterator as a source.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class php_iterator implements iterator {
+    protected $steptype;
+    protected $finished = false;
+    protected $input;
+    protected $step;
+
+    public function __construct(step_executor $step, \Iterator $input) {
+        $this->step = $step;
+        $this->input = $input;
+        $this->steptype = $step->steptype;
+    }
+
+    public function is_finished(): bool {
+        return $this->finished;
+    }
+
+    public function is_ready(): bool {
+        return !$this->finished && $this->input->valid();
+    }
+
+    public function abort() {
+        $this->finished = true;
+    }
+
+    public function next() {
+        if ($this->finished) {
+            return false;
+        }
+        try {
+            $value = $this->input->current();
+            $this->input->next();
+            if (!$this->input->valid()) {
+                $this->abort();
+            }
+            $newvalue = $this->steptype->execute($value);
+            return $newvalue;
+        } catch (\Throwable $exception) {
+            $this->step->dataflow->abort($this->step, $exception);
+        }
+    }
+}

--- a/classes/step/base_step.php
+++ b/classes/step/base_step.php
@@ -18,6 +18,9 @@ namespace tool_dataflows\step;
 
 use tool_dataflows\execution\engine;
 use tool_dataflows\execution\engine_step;
+use tool_dataflows\execution\iterators\iterator;
+use tool_dataflows\execution\iterators\map_iterator;
+use tool_dataflows\execution\flow_engine_step;
 
 /**
  * Base class for steps
@@ -35,7 +38,6 @@ abstract class base_step {
      * This is autopopulated by the dataflows manager.
      */
     protected $component = 'tool_dataflows';
-
 
     /** @var int[] number of input streams (min, max) */
     protected $inputstreams = [0, 1];
@@ -65,9 +67,9 @@ abstract class base_step {
      * Does this type define a flow step?
      * @return bool
      */
-    abstract function is_flow(): bool;
+    abstract public function is_flow(): bool;
 
-        /**
+    /**
      * Get the step's id
      *
      * This defaults to the base name of the class which is ok in the most
@@ -107,6 +109,13 @@ abstract class base_step {
     }
 
     /**
+     * For connectors, perform the task.
+     */
+    public function do_task(): bool {
+        return true;
+    }
+
+    /**
      * Step callback handler
      *
      * Implementation can vary, this might be a transformer, resource, or
@@ -140,5 +149,15 @@ abstract class base_step {
      * @return engine_step
      */
     abstract public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step;
-}
 
+    /**
+     * Get the iterator for the step, based on configurations.
+     *
+     * @param flow_engine_step $step
+     * @return iterator
+     */
+    public function get_iterator(flow_engine_step $step): iterator {
+        $input = current($step->upstreams)->iterator;
+        return new map_iterator($step, $input);
+    }
+}

--- a/classes/step/base_step.php
+++ b/classes/step/base_step.php
@@ -109,21 +109,6 @@ abstract class base_step {
     }
 
     /**
-     * For connectors, perform the task.
-     */
-    public function do_task(): bool {
-        return true;
-    }
-
-    /**
-     * Step callback handler
-     *
-     * Implementation can vary, this might be a transformer, resource, or
-     * something else.
-     */
-    abstract public function execute($input);
-
-    /**
      * Returns the [min, max] number of input streams
      *
      * @return     int[] of 2 ints, min and max values for the stream
@@ -149,15 +134,4 @@ abstract class base_step {
      * @return engine_step
      */
     abstract public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step;
-
-    /**
-     * Get the iterator for the step, based on configurations.
-     *
-     * @param flow_engine_step $step
-     * @return iterator
-     */
-    public function get_iterator(flow_engine_step $step): iterator {
-        $input = current($step->upstreams)->iterator;
-        return new map_iterator($step, $input);
-    }
 }

--- a/classes/step/base_step.php
+++ b/classes/step/base_step.php
@@ -16,6 +16,9 @@
 
 namespace tool_dataflows\step;
 
+use tool_dataflows\execution\engine;
+use tool_dataflows\execution\engine_step;
+
 /**
  * Base class for steps
  *
@@ -59,6 +62,12 @@ abstract class base_step {
     }
 
     /**
+     * Does this type define a flow step?
+     * @return bool
+     */
+    abstract function is_flow(): bool;
+
+        /**
      * Get the step's id
      *
      * This defaults to the base name of the class which is ok in the most
@@ -122,5 +131,14 @@ abstract class base_step {
     public function get_number_of_output_streams() {
         return $this->outputstreams;
     }
+
+    /**
+     * Generates an engine step for this type.
+     *
+     * @param engine $engine
+     * @param \tool_dataflows\step $stepdef
+     * @return engine_step
+     */
+    abstract public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step;
 }
 

--- a/classes/step/connector_step.php
+++ b/classes/step/connector_step.php
@@ -18,18 +18,32 @@ namespace tool_dataflows\step;
 
 use tool_dataflows\execution\engine;
 use tool_dataflows\execution\engine_step;
-use tool_dataflows\execution\engine_flow_cap;
+use tool_dataflows\execution\connector_engine_step;
 
 /**
- * A special, virtual flow step that is attached to the end of a flow block.
+ * Base class for connector step types.
  *
  * @package   tool_dataflows
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+abstract class connector_step extends base_step {
 
-class flow_cap extends flow_step {
+    /**
+     * Does this type define a flow step?
+     * @return bool
+     */
+    final public function is_flow(): bool {
+        return false;
+    }
+
+    /**
+     * Perform the task required by this connector.
+     *
+     * @return bool Returns true if successful, false otherwise.
+     */
+    abstract public function do_task(): bool;
 
     /**
      * Generates an engine step for this type.
@@ -39,6 +53,7 @@ class flow_cap extends flow_step {
      * @return engine_step
      */
     public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        return new engine_flow_cap($engine, $stepdef, $this);
+        // This should be sufficient for most cases. Override this function if needed.
+        return new connector_engine_step($engine, $stepdef, $this);
     }
 }

--- a/classes/step/debugging.php
+++ b/classes/step/debugging.php
@@ -16,6 +16,10 @@
 
 namespace tool_dataflows\step;
 
+use tool_dataflows\execution\engine;
+use tool_dataflows\execution\engine_step;
+use tool_dataflows\execution\flow_engine_step;
+
 /**
  * Step type: debugging
  *
@@ -25,6 +29,14 @@ namespace tool_dataflows\step;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class debugging extends base_step {
+
+    /**
+     * Does this type define a flow step?
+     * @return bool
+     */
+    function is_flow(): bool {
+        return true;
+    }
 
     /**
      * Executes the step
@@ -38,5 +50,17 @@ class debugging extends base_step {
         $output = $input;
         debugging(json_encode($input));
         return $output;
+    }
+
+    /**
+     * Generates an engine step for this type.
+     *
+     * @param engine $engine
+     * @param \tool_dataflows\step $stepdef
+     * @return engine_step
+     */
+    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
+        // This should be sufficient for most cases. Override this function if needed.
+        return new flow_engine_step($engine, $stepdef, $this);
     }
 }

--- a/classes/step/debugging.php
+++ b/classes/step/debugging.php
@@ -16,10 +16,6 @@
 
 namespace tool_dataflows\step;
 
-use tool_dataflows\execution\engine;
-use tool_dataflows\execution\engine_step;
-use tool_dataflows\execution\flow_engine_step;
-
 /**
  * Step type: debugging
  *
@@ -28,15 +24,7 @@ use tool_dataflows\execution\flow_engine_step;
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class debugging extends base_step {
-
-    /**
-     * Does this type define a flow step?
-     * @return bool
-     */
-    public function is_flow(): bool {
-        return true;
-    }
+class debugging extends flow_step {
 
     /**
      * Executes the step
@@ -50,17 +38,5 @@ class debugging extends base_step {
         $output = $input;
         debugging(json_encode($input));
         return $output;
-    }
-
-    /**
-     * Generates an engine step for this type.
-     *
-     * @param engine $engine
-     * @param \tool_dataflows\step $stepdef
-     * @return engine_step
-     */
-    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        // This should be sufficient for most cases. Override this function if needed.
-        return new flow_engine_step($engine, $stepdef, $this);
     }
 }

--- a/classes/step/debugging.php
+++ b/classes/step/debugging.php
@@ -34,7 +34,7 @@ class debugging extends base_step {
      * Does this type define a flow step?
      * @return bool
      */
-    function is_flow(): bool {
+    public function is_flow(): bool {
         return true;
     }
 

--- a/classes/step/flow_cap.php
+++ b/classes/step/flow_cap.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,33 +18,18 @@ namespace tool_dataflows\step;
 
 use tool_dataflows\execution\engine;
 use tool_dataflows\execution\engine_step;
-use tool_dataflows\execution\flow_engine_step;
+use tool_dataflows\execution\engine_flow_cap;
 
 /**
- * Step type: join
+ * A special, virtual flow step that is attached to the end of a flow block.
  *
- * @package    tool_dataflows
- * @author     Kevin Pham <kevinpham@catalyst-au.net>
- * @copyright  Catalyst IT, 2022
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package   <insert>
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class join extends base_step {
 
-    /**
-     * @var int[] number of input streams (min, max)
-     *
-     * For a join step, it should have 2 or more inputs and for now, up to 20
-     * possible input streams.
-     */
-    protected $inputstreams = [2, 20];
-
-    /**
-     * @var int[] number of output streams (min, max)
-     *
-     * For a join step, there should be exactly one output. This is because
-     * without at least one output, there is no need to perform a join.
-     */
-    protected $outputstreams = [1, 1];
+class flow_cap extends base_step {
 
     /**
      * Does this type define a flow step?
@@ -57,9 +42,7 @@ class join extends base_step {
     /**
      * Executes the step
      *
-     * This step not perform any operations, but instead waits for all
-     * dependencies to be complete before continuing. This passes the input
-     * as-is to the output.
+     * Does nothing.
      *
      * @param mixed $input
      * @return mixed $output
@@ -77,6 +60,6 @@ class join extends base_step {
      */
     public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
         // This should be sufficient for most cases. Override this function if needed.
-        return new flow_engine_step($engine, $stepdef, $this);
+        return new engine_flow_cap($engine, $stepdef, $this);
     }
 }

--- a/classes/step/flow_step.php
+++ b/classes/step/flow_step.php
@@ -18,18 +18,38 @@ namespace tool_dataflows\step;
 
 use tool_dataflows\execution\engine;
 use tool_dataflows\execution\engine_step;
-use tool_dataflows\execution\engine_flow_cap;
+use tool_dataflows\execution\iterators\iterator;
+use tool_dataflows\execution\iterators\map_iterator;
+use tool_dataflows\execution\flow_engine_step;
 
 /**
- * A special, virtual flow step that is attached to the end of a flow block.
+ * Base class for flow step types.
  *
  * @package   tool_dataflows
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+abstract class flow_step extends base_step {
 
-class flow_cap extends flow_step {
+    /**
+     * Does this type define a flow step?
+     * @return bool
+     */
+    final public function is_flow(): bool {
+        return true;
+    }
+
+    /**
+     * Step callback handler
+     *
+     * Implementation can vary, this might be a transformer, resource, or
+     * something else.
+     */
+    public function execute($input) {
+        // Default is to do nothing.
+        return $input;
+    }
 
     /**
      * Generates an engine step for this type.
@@ -39,6 +59,19 @@ class flow_cap extends flow_step {
      * @return engine_step
      */
     public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        return new engine_flow_cap($engine, $stepdef, $this);
+        // This should be sufficient for most cases. Override this function if needed.
+        return new flow_engine_step($engine, $stepdef, $this);
+    }
+
+    /**
+     * Get the iterator for the step, based on configurations.
+     *
+     * @param flow_engine_step $step
+     * @return iterator
+     */
+    public function get_iterator(flow_engine_step $step): iterator {
+        // Default is to simply map.
+        $input = current($step->upstreams)->iterator;
+        return new map_iterator($step, $input);
     }
 }

--- a/classes/step/join.php
+++ b/classes/step/join.php
@@ -16,19 +16,18 @@
 
 namespace tool_dataflows\step;
 
-use tool_dataflows\execution\engine;
-use tool_dataflows\execution\engine_step;
-use tool_dataflows\execution\flow_engine_step;
-
 /**
  * Step type: join
+ *
+ * This step not perform any operations, but instead waits for all
+ * dependencies to be complete before continuing.
  *
  * @package    tool_dataflows
  * @author     Kevin Pham <kevinpham@catalyst-au.net>
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class join extends base_step {
+class join extends flow_step {
 
     /**
      * @var int[] number of input streams (min, max)
@@ -45,38 +44,4 @@ class join extends base_step {
      * without at least one output, there is no need to perform a join.
      */
     protected $outputstreams = [1, 1];
-
-    /**
-     * Does this type define a flow step?
-     * @return bool
-     */
-    public function is_flow(): bool {
-        return true;
-    }
-
-    /**
-     * Executes the step
-     *
-     * This step not perform any operations, but instead waits for all
-     * dependencies to be complete before continuing. This passes the input
-     * as-is to the output.
-     *
-     * @param mixed $input
-     * @return mixed $output
-     */
-    public function execute($input) {
-        return $input;
-    }
-
-    /**
-     * Generates an engine step for this type.
-     *
-     * @param engine $engine
-     * @param \tool_dataflows\step $stepdef
-     * @return engine_step
-     */
-    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        // This should be sufficient for most cases. Override this function if needed.
-        return new flow_engine_step($engine, $stepdef, $this);
-    }
 }

--- a/classes/step/join.php
+++ b/classes/step/join.php
@@ -16,6 +16,10 @@
 
 namespace tool_dataflows\step;
 
+use tool_dataflows\execution\engine;
+use tool_dataflows\execution\engine_step;
+use tool_dataflows\execution\flow_engine_step;
+
 /**
  * Step type: join
  *
@@ -43,6 +47,14 @@ class join extends base_step {
     protected $outputstreams = [1, 1];
 
     /**
+     * Does this type define a flow step?
+     * @return bool
+     */
+    function is_flow(): bool {
+        return true;
+    }
+
+    /**
      * Executes the step
      *
      * This step not perform any operations, but instead waits for all
@@ -54,5 +66,17 @@ class join extends base_step {
      */
     public function execute($input) {
         return $input;
+    }
+
+    /**
+     * Generates an engine step for this type.
+     *
+     * @param engine $engine
+     * @param \tool_dataflows\step $stepdef
+     * @return engine_step
+     */
+    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
+        // This should be sufficient for most cases. Override this function if needed.
+        return new flow_engine_step($engine, $stepdef, $this);
     }
 }

--- a/classes/step/mtrace.php
+++ b/classes/step/mtrace.php
@@ -34,7 +34,7 @@ class mtrace extends base_step {
      * Does this type define a flow step?
      * @return bool
      */
-    function is_flow(): bool {
+    public function is_flow(): bool {
         return true;
     }
 

--- a/classes/step/mtrace.php
+++ b/classes/step/mtrace.php
@@ -16,10 +16,6 @@
 
 namespace tool_dataflows\step;
 
-use tool_dataflows\execution\engine;
-use tool_dataflows\execution\engine_step;
-use tool_dataflows\execution\flow_engine_step;
-
 /**
  * Step type: mtrace
  *
@@ -28,15 +24,7 @@ use tool_dataflows\execution\flow_engine_step;
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mtrace extends base_step {
-
-    /**
-     * Does this type define a flow step?
-     * @return bool
-     */
-    public function is_flow(): bool {
-        return true;
-    }
+class mtrace extends flow_step {
 
     /**
      * Executes the step
@@ -50,17 +38,5 @@ class mtrace extends base_step {
         $output = $input;
         mtrace(json_encode($input));
         return $output;
-    }
-
-    /**
-     * Generates an engine step for this type.
-     *
-     * @param engine $engine
-     * @param \tool_dataflows\step $stepdef
-     * @return engine_step
-     */
-    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        // This should be sufficient for most cases. Override this function if needed.
-        return new flow_engine_step($engine, $stepdef, $this);
     }
 }

--- a/classes/step/mtrace.php
+++ b/classes/step/mtrace.php
@@ -16,6 +16,10 @@
 
 namespace tool_dataflows\step;
 
+use tool_dataflows\execution\engine;
+use tool_dataflows\execution\engine_step;
+use tool_dataflows\execution\flow_engine_step;
+
 /**
  * Step type: mtrace
  *
@@ -25,6 +29,14 @@ namespace tool_dataflows\step;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class mtrace extends base_step {
+
+    /**
+     * Does this type define a flow step?
+     * @return bool
+     */
+    function is_flow(): bool {
+        return true;
+    }
 
     /**
      * Executes the step
@@ -38,5 +50,17 @@ class mtrace extends base_step {
         $output = $input;
         mtrace(json_encode($input));
         return $output;
+    }
+
+    /**
+     * Generates an engine step for this type.
+     *
+     * @param engine $engine
+     * @param \tool_dataflows\step $stepdef
+     * @return engine_step
+     */
+    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
+        // This should be sufficient for most cases. Override this function if needed.
+        return new flow_engine_step($engine, $stepdef, $this);
     }
 }

--- a/classes/step/void_step.php
+++ b/classes/step/void_step.php
@@ -16,6 +16,10 @@
 
 namespace tool_dataflows\step;
 
+use tool_dataflows\execution\engine;
+use tool_dataflows\execution\engine_step;
+use tool_dataflows\execution\flow_engine_step;
+
 /**
  * Step type: void
  *
@@ -27,6 +31,14 @@ namespace tool_dataflows\step;
 class void_step extends base_step {
 
     /**
+     * Does this type define a flow step?
+     * @return bool
+     */
+    function is_flow(): bool {
+        return true;
+    }
+
+    /**
      * Executes the step
      *
      * This will simply return nothing, causing the output chain to be empty
@@ -36,5 +48,17 @@ class void_step extends base_step {
      */
     public function execute($input) {
         return;
+    }
+
+    /**
+     * Generates an engine step for this type.
+     *
+     * @param engine $engine
+     * @param \tool_dataflows\step $stepdef
+     * @return engine_step
+     */
+    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
+        // This should be sufficient for most cases. Override this function if needed.
+        return new flow_engine_step($engine, $stepdef, $this);
     }
 }

--- a/classes/step/void_step.php
+++ b/classes/step/void_step.php
@@ -34,7 +34,7 @@ class void_step extends base_step {
      * Does this type define a flow step?
      * @return bool
      */
-    function is_flow(): bool {
+    public function is_flow(): bool {
         return true;
     }
 

--- a/classes/step/void_step.php
+++ b/classes/step/void_step.php
@@ -28,15 +28,7 @@ use tool_dataflows\execution\flow_engine_step;
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class void_step extends base_step {
-
-    /**
-     * Does this type define a flow step?
-     * @return bool
-     */
-    public function is_flow(): bool {
-        return true;
-    }
+class void_step extends flow_step {
 
     /**
      * Executes the step
@@ -48,17 +40,5 @@ class void_step extends base_step {
      */
     public function execute($input) {
         return;
-    }
-
-    /**
-     * Generates an engine step for this type.
-     *
-     * @param engine $engine
-     * @param \tool_dataflows\step $stepdef
-     * @return engine_step
-     */
-    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        // This should be sufficient for most cases. Override this function if needed.
-        return new flow_engine_step($engine, $stepdef, $this);
     }
 }

--- a/tests/execution/array_in_type.php
+++ b/tests/execution/array_in_type.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,56 +14,36 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_dataflows\step;
+namespace tool_dataflows\execution;
 
-use tool_dataflows\execution\engine;
-use tool_dataflows\execution\engine_step;
+use tool_dataflows\execution\iterators\iterator;
+use tool_dataflows\execution\iterators\php_iterator;
 use tool_dataflows\execution\flow_engine_step;
+use tool_dataflows\step\base_step;
 
 /**
- * Step type: join
+ * Test reader step type that supplies an array.
+ * TODO: Until better classes have been defined, this is GEFN (Good Enough For Now).
  *
- * @package    tool_dataflows
- * @author     Kevin Pham <kevinpham@catalyst-au.net>
- * @copyright  Catalyst IT, 2022
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class join extends base_step {
 
-    /**
-     * @var int[] number of input streams (min, max)
-     *
-     * For a join step, it should have 2 or more inputs and for now, up to 20
-     * possible input streams.
-     */
-    protected $inputstreams = [2, 20];
+class array_in_type extends base_step {
 
-    /**
-     * @var int[] number of output streams (min, max)
-     *
-     * For a join step, there should be exactly one output. This is because
-     * without at least one output, there is no need to perform a join.
-     */
-    protected $outputstreams = [1, 1];
-
-    /**
-     * Does this type define a flow step?
-     * @return bool
-     */
     public function is_flow(): bool {
         return true;
     }
 
-    /**
-     * Executes the step
-     *
-     * This step not perform any operations, but instead waits for all
-     * dependencies to be complete before continuing. This passes the input
-     * as-is to the output.
-     *
-     * @param mixed $input
-     * @return mixed $output
-     */
+    /** @var array The source. Place dat here before use. */
+    public static $source = [];
+
+    public function get_iterator(flow_engine_step $step): iterator {
+        return new php_iterator($step, new \ArrayIterator(self::$source));
+    }
+
     public function execute($input) {
         return $input;
     }

--- a/tests/execution/array_out_type.php
+++ b/tests/execution/array_out_type.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,57 +14,38 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_dataflows\step;
+namespace tool_dataflows\execution;
 
-use tool_dataflows\execution\engine;
-use tool_dataflows\execution\engine_step;
+use tool_dataflows\execution\iterators\iterator;
+use tool_dataflows\execution\iterators\map_iterator;
 use tool_dataflows\execution\flow_engine_step;
+use tool_dataflows\step\base_step;
 
 /**
- * Step type: join
+ * Test writer step type that writes to an array.
+ * TODO: Until better classes have been defined, this is GEFN (Good Enough For Now).
  *
- * @package    tool_dataflows
- * @author     Kevin Pham <kevinpham@catalyst-au.net>
- * @copyright  Catalyst IT, 2022
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class join extends base_step {
+class array_out_type extends base_step {
 
-    /**
-     * @var int[] number of input streams (min, max)
-     *
-     * For a join step, it should have 2 or more inputs and for now, up to 20
-     * possible input streams.
-     */
-    protected $inputstreams = [2, 20];
+    /** @var array The output array that the dat is written into. Make sure it is empty before use. */
+    public static $dest = [];
 
-    /**
-     * @var int[] number of output streams (min, max)
-     *
-     * For a join step, there should be exactly one output. This is because
-     * without at least one output, there is no need to perform a join.
-     */
-    protected $outputstreams = [1, 1];
-
-    /**
-     * Does this type define a flow step?
-     * @return bool
-     */
     public function is_flow(): bool {
         return true;
     }
 
-    /**
-     * Executes the step
-     *
-     * This step not perform any operations, but instead waits for all
-     * dependencies to be complete before continuing. This passes the input
-     * as-is to the output.
-     *
-     * @param mixed $input
-     * @return mixed $output
-     */
+    public function get_iterator(flow_engine_step $step): iterator {
+        $input = current($step->upstreams)->iterator;
+        return new map_iterator($step, $input);
+    }
+
     public function execute($input) {
+        self::$dest[] = $input;
         return $input;
     }
 

--- a/tests/execution/tool_dataflows_basic_execution_test.php
+++ b/tests/execution/tool_dataflows_basic_execution_test.php
@@ -1,0 +1,85 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution;
+
+use tool_dataflows\execution\engine;
+use tool_dataflows\dataflow;
+use tool_dataflows\step;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/array_in_type.php"); // This is needed. File will not be automatically included.
+require_once(__DIR__ . "/array_out_type.php"); // This is needed. File will not be automatically included.
+
+/**
+ * Unit tests for the execution engine
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_basic_execution_test extends \advanced_testcase {
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Tests the minimal ability for the execution engine. Reads in array data from a reader,
+     * and passes it on to a writer.
+     *
+     * @throws \moodle_exception
+     */
+    public function test_in_and_out() {
+        $this->resetAfterTest();
+
+        // Crate the dataflow.
+        $dataflow = new dataflow();
+        $dataflow->name = 'two-step';
+        $dataflow->save();
+
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = 'tool_dataflows\execution\array_in_type';
+        $dataflow->add_step($reader);
+
+        $writer = new step();
+        $writer->name = 'writer';
+        $writer->type = 'tool_dataflows\execution\array_out_type';
+
+        $writer->depends_on([$reader]);
+        $dataflow->add_step($writer);
+
+        // Define the input.
+        $json = '[{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}]';
+
+        array_in_type::$source = json_decode($json);
+        array_out_type::$dest = [];
+
+        // Execute.
+        $engine = new engine($dataflow);
+        $engine->execute();
+
+        $this->assertEquals(array_in_type::$source, array_out_type::$dest);
+        $this->assertEquals(engine::STATUS_FINALISED, $engine->status);
+    }
+}

--- a/tests/execution/tool_dataflows_engine_test.php
+++ b/tests/execution/tool_dataflows_engine_test.php
@@ -1,0 +1,159 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\execution;
+
+use tool_dataflows\dataflow;
+use tool_dataflows\step;
+
+defined('MOODLE_INTERNAL') || die();
+
+/** Exposes all private fields for the purpose of testing them. */
+class test_engine extends engine {
+    public function __get($p) {
+        return $this->$p;
+    }
+}
+
+/**
+ * Unit tests covering the execution engine.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_engine_test extends \advanced_testcase {
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Test the construction of the engine to ensure it mirrors the dataflow defined by the user.
+     */
+    public function test_engine_construction() {
+
+        list($dataflow, $steps, $expectedsinks, $expectedflowsinks) = $this->dataflow_provider();
+
+        // Create the engine.
+        $engine = new test_engine($dataflow);
+
+        // Test that the engine has been created correctly.
+        $this->assertEquals(engine::STATUS_NEW, $engine->status);
+        $this->assertEquals($dataflow, $engine->dataflow);
+        $this->assertEquals(count($steps), count($engine->enginesteps));
+
+        foreach ($engine->enginesteps as $id => $enginestep) {
+            // Test the identity of the engine step.
+            $this->assertEquals(engine::STATUS_NEW, $enginestep->status);
+            $this->assertInstanceOf('\tool_dataflows\execution\engine_step', $enginestep);
+            $this->assertEquals($id, $enginestep->id);
+            $this->assertArrayHasKey($id, $steps);
+            $this->assertEquals($steps[$id]->id, $enginestep->stepdef->id);
+
+            // Test that the upstreams mirror the dependencies.
+            $upstreams = $enginestep->upstreams;
+            // Extract the IDs.
+            $deps = array_map(
+                function($dep) {
+                    return $dep->id;
+                },
+                $steps[$enginestep->id]->dependencies()
+            );
+            $this->assertEquals(count($deps), count($upstreams));
+            foreach ($upstreams as $upstream) {
+                // Test upstream set correctly.
+                $this->assertInstanceOf('\tool_dataflows\execution\engine_step', $upstream);
+                $this->assertTrue(in_array($upstream->id, $deps));
+                // Test downstream set correctly.
+                $this->assertArrayHasKey($id, $upstream->downstreams);
+                $this->assertEquals($enginestep, $upstream->downstreams[$id]);
+            }
+        }
+
+        // Test that sinks are properly found.
+        $sinks = array_map(
+            function($s) {
+                return $s->id;
+            },
+            $engine->sinks
+        );
+        $this->assertEquals($expectedsinks, $sinks);
+
+        // Test flow sinks.
+        // TODO: These tests may be weak.
+        $flowsinks = [];
+        $flowcaps = $engine->flowcaps;
+        foreach ($flowcaps as $cap) {
+            $flowsinks[] = array_values(
+                array_map(
+                    function($s) {
+                        return (int) $s->id;
+                    },
+                    $cap->upstreams
+                )
+            );
+        }
+        $this->assertEquals(count($expectedflowsinks), count($flowsinks));
+
+        foreach ($flowsinks as $flowsink) {
+            $this->assertTrue(in_array($flowsink, $expectedflowsinks));
+        }
+
+        // Test initialisation.
+        $engine->initialise();
+        foreach ($engine->enginesteps as $id => $enginestep) {
+            $this->assertEquals(engine::STATUS_INITIALISED, $enginestep->status);
+        }
+    }
+
+    /**
+     * Create a dataflow for testing.
+     *
+     * @return array
+     */
+    public function dataflow_provider(): array {
+        $dataflow = new dataflow();
+        $dataflow->name = 'two-step';
+        $dataflow->save();
+
+        $steps = [];
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = 'tool_dataflows\step\mtrace';
+        $dataflow->add_step($reader);
+        $steps[$reader->id] = $reader;
+
+        $writer = new step();
+        $writer->name = 'writer';
+        $writer->type = 'tool_dataflows\step\debugging';
+
+        $writer->depends_on([$reader]);
+        $dataflow->add_step($writer);
+        $steps[$writer->id] = $writer;
+
+        $expectedsinks = [$writer->id];
+
+        $expectedflowsinks = [[$writer->id]];
+
+        return [$dataflow, $steps, $expectedsinks, $expectedflowsinks];
+    }
+}


### PR DESCRIPTION
Resolves #29 

Adds an execution engine.
Requires https://github.com/catalyst/moodle-local_aws/pull/43

The refactoring of step type classes is needed to avoid a ton of repetition.
OK to squash
