### PR TITLE
Cancel form to do proper redirect

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -58,6 +58,9 @@ $customdata = [
     'userid' => $USER->id // For the hidden userid field.
 ];
 $form = new dataflow_form($PAGE->url->out(false), $customdata);
+if ($form->is_cancelled()) {
+    redirect($overviewurl);
+}
 
 
 if (($data = $form->get_data())) {

--- a/step.php
+++ b/step.php
@@ -73,6 +73,9 @@ $customdata = [
     'userid' => $USER->id, // For the hidden userid field.
 ];
 $form = new step_form($PAGE->url->out(false), $customdata);
+if ($form->is_cancelled()) {
+    redirect($dataflowstepsurl);
+}
 
 // Populate the foreign dependencies data if there was any.
 if (!empty($dependencies)) {


### PR DESCRIPTION
- fix: cancel step form now redirects to the dataflow steps list page
- fix: cancel dataflow form now redirects to the dataflows overview page

Resolves #71 
