### PR TITLE
fix: step add/edit page query param handling

### DIFF
--- a/classes/steps_table.php
+++ b/classes/steps_table.php
@@ -76,7 +76,7 @@ class steps_table extends \table_sql {
      * @return string
      */
     public function col_name(\stdClass $record): string {
-        $url = new \moodle_url('/admin/tool/dataflows/step.php', ['id' => $record->id, 'dataflowid' => $record->dataflowid]);
+        $url = new \moodle_url('/admin/tool/dataflows/step.php', ['id' => $record->id]);
         return \html_writer::link($url, $record->name);
     }
 


### PR DESCRIPTION
Note that dataflow is only required when adding a new step, and is otherwise loaded from the step record if that is provided instead.

Updated the table links to reflect the new changes

![image](https://user-images.githubusercontent.com/9924643/169933473-5acf457c-c1f8-48e5-9ce5-ef0adbc8afea.png)

Resolves #81 