### PR TITLE
Issue #102: Fix dataflow run error

### DIFF
--- a/classes/step/flow_step.php
+++ b/classes/step/flow_step.php
@@ -32,6 +32,10 @@ use tool_dataflows\execution\flow_engine_step;
  */
 abstract class flow_step extends base_step {
 
+    /** @var int[] number of input streams (min, max) */
+    // Flow steps default to min 1 input.
+    protected $inputstreams = [1, 1];
+
     /**
      * Does this type define a flow step?
      * @return bool
@@ -71,7 +75,10 @@ abstract class flow_step extends base_step {
      */
     public function get_iterator(flow_engine_step $step): iterator {
         // Default is to simply map.
-        $input = current($step->upstreams)->iterator;
-        return new map_iterator($step, $input);
+        $upstream = current($step->upstreams);
+        if ($upstream === false || !$upstream->is_flow()) {
+            throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
+        }
+        return new map_iterator($step, $upstream->iterator);
     }
 }

--- a/classes/step/flow_step.php
+++ b/classes/step/flow_step.php
@@ -32,8 +32,7 @@ use tool_dataflows\execution\flow_engine_step;
  */
 abstract class flow_step extends base_step {
 
-    /** @var int[] number of input streams (min, max) */
-    // Flow steps default to min 1 input.
+    /** @var int[] number of input streams (min, max). Flow steps default to min 1 input. */
     protected $inputstreams = [1, 1];
 
     /**

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -73,6 +73,7 @@ $string['stepinvalidoutputstreamcount'] = 'Invalid number of output streams for 
 $string['bad_parameter'] = 'Parameter \'{$a->parameter}\' not supported in \'{$a->classname}\'.';
 $string['config_field_missing'] = 'Config \'{$a}\' missing.';
 $string['invalid_config'] = 'Invalid configuration';
+$string['non_reader_steps_must_have_flow_upstreams'] = 'Non reader steps must have at least one flow step dependency.';
 
 // Privacy.
 $string['privacy:metadata:dataflows'] = 'Data from the configured dataflows';

--- a/tests/execution/array_in_type.php
+++ b/tests/execution/array_in_type.php
@@ -33,6 +33,9 @@ use tool_dataflows\step\base_step;
 
 class array_in_type extends base_step {
 
+    /** @var int[] number of input streams (min, max), zero for readers. */
+    protected $inputstreams = [0, 0];
+
     public function is_flow(): bool {
         return true;
     }

--- a/tests/execution/tool_dataflows_basic_execution_test.php
+++ b/tests/execution/tool_dataflows_basic_execution_test.php
@@ -22,8 +22,10 @@ use tool_dataflows\step;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once(__DIR__ . "/array_in_type.php"); // This is needed. File will not be automatically included.
-require_once(__DIR__ . "/array_out_type.php"); // This is needed. File will not be automatically included.
+// This is needed. File will not be automatically included.
+require_once(__DIR__ . '/array_in_type.php');
+// This is needed. File will not be automatically included.
+require_once(__DIR__ . '/array_out_type.php');
 
 /**
  * Unit tests for the execution engine

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -22,8 +22,9 @@ use Symfony\Component\Yaml\Yaml;
 defined('MOODLE_INTERNAL') || die();
 
 // Include lib.php functions that aren't included automatically for Moodle 37- and below.
-require_once(dirname(__FILE__) . '/../lib.php');
-require_once(__DIR__ . "/execution/array_in_type.php"); // This is needed. File will not be automatically included.
+require_once(__DIR__ . '/../lib.php');
+// This is needed. File will not be automatically included.
+require_once(__DIR__ . '/execution/array_in_type.php');
 
 /**
  * Units tests for tool_dataflows

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -23,6 +23,7 @@ defined('MOODLE_INTERNAL') || die();
 
 // Include lib.php functions that aren't included automatically for Moodle 37- and below.
 require_once(dirname(__FILE__) . '/../lib.php');
+require_once(__DIR__ . "/execution/array_in_type.php"); // This is needed. File will not be automatically included.
 
 /**
  * Units tests for tool_dataflows
@@ -94,7 +95,7 @@ class tool_dataflows_test extends \advanced_testcase {
 
         $stepone = new \tool_dataflows\step();
         $stepone->name = 'step1';
-        $stepone->type = step\debugging::class;
+        $stepone->type = execution\array_in_type::class;
         $dataflow->add_step($stepone);
 
         $steptwo = new \tool_dataflows\step();
@@ -136,7 +137,7 @@ class tool_dataflows_test extends \advanced_testcase {
 
         $stepone = new \tool_dataflows\step();
         $stepone->name = 'step1';
-        $stepone->type = step\debugging::class;
+        $stepone->type = execution\array_in_type::class;
         $dataflow->add_step($stepone);
 
         $steptwo = new \tool_dataflows\step();


### PR DESCRIPTION
Resolves #102 
Make 1 inputstream the default min requirement for flow steps.
Add check that mapping steps have at least 1 input.
Add inputstream restriction to array_in_type.
Change use of debugging steptypes to array_in in unit tests.

OK to squash.