### PR TITLE
Issue #131: Change run now button to match validation

### DIFF
--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -193,7 +193,7 @@ class visualiser {
             $buttoncolour = 'btn-success';
             $buttonicon = 't/go';
         } else {
-            $buttoncolour = 'btn-danger ';
+            $buttoncolour = 'btn-danger';
             $buttonicon = 't/stop';
         }
         $runurl = new \moodle_url(

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -189,17 +189,24 @@ class visualiser {
         $validation = $dataflow->validate_dataflow();
 
         // Display the run now button (disabling it if dataflow is not valid).
+        if ($validation === true) {
+            $buttoncolour = 'btn-success';
+            $buttonicon = 't/go';
+        } else {
+            $buttoncolour = 'btn-danger ';
+            $buttonicon = 't/stop';
+        }
         $runurl = new \moodle_url(
             '/admin/tool/dataflows/run.php',
             [
                 'dataflowid' => $dataflow->id,
                 'returnurl' => $PAGE->url->out(false),
             ]);
-        $runbuttonattributes = ['class' => 'btn btn-warning'];
+        $runbuttonattributes = ['class' => 'btn ' . $buttoncolour];
         if ($validation !== true) {
             $runbuttonattributes['disabled'] = true;
         }
-        $icon = $output->render(new \pix_icon('t/go', get_string('run_now', 'tool_dataflows')));
+        $icon = $output->render(new \pix_icon($buttonicon, get_string('run_now', 'tool_dataflows')));
         $runbutton = \html_writer::tag('button', $icon . get_string('run_now', 'tool_dataflows'), $runbuttonattributes);
         echo \html_writer::link($runurl, $runbutton);
 
@@ -217,7 +224,7 @@ class visualiser {
         $exportbtn = \html_writer::tag(
             'button',
             $icon . get_string('edit'),
-            ['class' => 'btn btn-secondary mx-2' ]
+            ['class' => 'btn btn-secondary mx-2']
         );
         echo \html_writer::link($importurl, $exportbtn);
 

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -194,7 +194,7 @@ class visualiser {
             $buttonicon = 't/go';
         } else {
             $buttoncolour = 'btn-danger';
-            $buttonicon = 't/stop';
+            $buttonicon = 't/block';
         }
         $runurl = new \moodle_url(
             '/admin/tool/dataflows/run.php',


### PR DESCRIPTION
Resolves #131 

Change button colour to be danger for invalid, success for valid.
Change icon to show stop icon when invalid.
![Screenshot from 2022-06-06 11-31-28](https://user-images.githubusercontent.com/1052990/172080160-8f040b5f-b7c6-4c0f-b36e-0d59ded456e4.png)
![Screenshot from 2022-06-06 11-31-58](https://user-images.githubusercontent.com/1052990/172080172-77b72ada-1f5a-4d3e-9ceb-2c4280fbba61.png)

