### PR TITLE
5 variable setting from engine run

### DIFF
--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -272,6 +272,7 @@ class engine {
             case 'status':
             case 'exception':
             case 'isdryrun':
+            case 'dataflow':
                 return $this->$parameter;
             case 'name':
                 return $this->dataflow->name;
@@ -282,5 +283,18 @@ class engine {
                     '',
                     ['parameter' => $parameter, 'classname' => self::class]);
         }
+    }
+
+    /**
+     * Returns an array with all the variables available through the dataflow engine.
+     *
+     * Note: ideally, you could check a value set in another step via this
+     * function, and returning the dataflow->variables might not always be the
+     * correct choice, thus the need for this function should things be updated.
+     *
+     * @return  array
+     */
+    public function get_variables(): array {
+        return $this->dataflow->variables;
     }
 }

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -153,10 +153,14 @@ class engine {
      */
     protected function create_flow_caps() {
         // TODO Currently assumes flow blocks have no branches.
+        $flowcaps = 0;
         foreach ($this->enginesteps as $enginestep) {
             if ($enginestep->is_flow() && count($enginestep->downstreams) == 0) {
                 $steptype = new flow_cap();
-                $flowcap = $steptype->get_engine_step($this, new \tool_dataflows\step());
+                $step = new \tool_dataflows\step();
+                $flowcaps++;
+                $step->name = "flowcap-{$flowcaps}";
+                $flowcap = $steptype->get_engine_step($this, $step);
                 $this->flowcaps[] = $flowcap;
                 $enginestep->downstreams['puller'] = $flowcap;
                 $flowcap->upstreams[$enginestep->id] = $enginestep;

--- a/classes/local/execution/engine_step.php
+++ b/classes/local/execution/engine_step.php
@@ -189,7 +189,13 @@ abstract class engine_step {
      */
     public function set_var($name, $value) {
         // Check if this is an available field to set in the step type.
-        // TODO: implement.
+        if (!$this->steptype->is_field_valid($name)) {
+            $stepurl = new \moodle_url('/admin/tool/dataflows/step.php', ['id' => $this->stepdef->id]);
+            throw new \moodle_exception('variablefieldnotexpected', 'tool_dataflows', $stepurl, (object) [
+                'field' => $name,
+                'steptype' => $this->steptype->get_id(),
+            ]);
+        }
 
         // Check if this field can be updated or not, e.g. if this was forced in config, it should not be updatable.
         // TODO: implement.

--- a/classes/local/execution/engine_step.php
+++ b/classes/local/execution/engine_step.php
@@ -173,4 +173,35 @@ abstract class engine_step {
     public function log(string $message) {
         mtrace('Engine \'' . $this->engine->name . '\', step \'' . $this->name . '\': ' . $message);
     }
+
+    /**
+     * Sets a variable, at the path provided.
+     *
+     * Currently, this will set it into the step's configuration.
+     *
+     * TODO: later this might only set it into the instance's history record,
+     * such that failed execution can be continued without creating a new 'run'.
+     * For example, set_var always goes to instance vars, set_config always
+     * updates step's config.
+     *
+     * @param      string name or path to name of field e.g. 'some.nested.fieldname'
+     * @param      mixed value
+     */
+    public function set_var($name, $value) {
+        // Check if this is an available field to set in the step type.
+        // TODO: implement.
+
+        // Check if this field can be updated or not, e.g. if this was forced in config, it should not be updatable.
+        // TODO: implement.
+
+        $previous = $this->stepdef->config->{$name};
+        $this->log("Setting '$name' to '$value' (from '{$previous}')");
+        $this->stepdef->set_var($name, $value);
+
+        // Persists the variable to the dataflow step config.
+        // NOTE: This is skipped during a dry-run. Variables 'should' still be accessible as per normal.
+        if (!$this->engine->isdryrun) {
+            $this->stepdef->save();
+        }
+    }
 }

--- a/classes/local/execution/flow_engine_step.php
+++ b/classes/local/execution/flow_engine_step.php
@@ -72,4 +72,20 @@ class flow_engine_step extends engine_step {
         }
         return $this->status;
     }
+
+    /**
+     * Returns an array with all the variables available, with the context of the step
+     *
+     * @return  array
+     */
+    public function get_variables(): array {
+        // Config values are directly referenceable, step values go through
+        // step.fieldname, everything else is available through expressions,
+        // such as 'dataflow.id' and 'steps.mystep.name' for example.
+        return array_merge(
+            $this->engine->get_variables(),
+            ['step' => $this->stepdef],
+            (array) $this->stepdef->config,
+        );
+    }
 }

--- a/classes/local/execution/flow_engine_step.php
+++ b/classes/local/execution/flow_engine_step.php
@@ -85,7 +85,7 @@ class flow_engine_step extends engine_step {
         return array_merge(
             $this->engine->get_variables(),
             ['step' => $this->stepdef],
-            (array) $this->stepdef->config,
+            (array) $this->stepdef->config
         );
     }
 }

--- a/classes/local/execution/iterators/php_iterator.php
+++ b/classes/local/execution/iterators/php_iterator.php
@@ -79,6 +79,15 @@ class php_iterator implements iterator {
         if ($this->finished) {
             return false;
         }
+
+        // Only performs this check on the first iteration, and aborts if the
+        // iterator's position is valid (e.g. has no data).
+        if ($this->iterationcount === 0 && !$this->input->valid()) {
+            $this->step->log('Aborting at iteration ' . $this->iterationcount . '. No data?');
+            $this->abort();
+            return false;
+        }
+
         $value = $this->input->current();
         $this->input->next();
         if (!$this->input->valid()) {

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -30,6 +30,9 @@ use tool_dataflows\local\execution\engine_step;
  */
 abstract class base_step {
 
+    /** @var engine_step */
+    protected $enginestep;
+
     /**
      * This is autopopulated by the dataflows manager.
      *
@@ -337,5 +340,15 @@ abstract class base_step {
             'fontname'  => 'Arial',
             'style'     => 'filled',
         ];
+    }
+
+    /**
+     * Returns whether or not a field is defined in the form
+     *
+     * @param      string $fieldname name of the field
+     * @return     bool whether or not the provided field is defined
+     */
+    public function is_field_valid(string $fieldname): bool {
+        return isset(static::form_define_fields()[$fieldname]);
     }
 }

--- a/classes/local/step/flow_transformer_filter.php
+++ b/classes/local/step/flow_transformer_filter.php
@@ -17,14 +17,14 @@
 namespace tool_dataflows\local\step;
 
 /**
- * Base class for flow transformer step types.
+ * Flow filter (transformer step) class
  *
  * @package    tool_dataflows
  * @author     Kevin Pham <kevinpham@catalyst-au.net>
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class flow_transformer_step extends flow_step {
+class flow_transformer_filter extends flow_transformer_step {
 
     /** @var int[] number of input flows (min, max). */
     protected $inputflows = [1, 1];
@@ -33,9 +33,11 @@ abstract class flow_transformer_step extends flow_step {
     protected $outputflows = [1, 1];
 
     /**
-     * {@inheritdoc}
+     * Apply the filter based on configuration
      */
-    final public function get_group(): string {
-        return 'flowtransformers';
+    public function execute($record) {
+        // TODO: implement.
+        return $record;
     }
 }
+

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -97,7 +97,7 @@ class reader_sql extends reader_step {
             // Check expression evaluation using the current config object
             // first, then failing that, target the dataflow variables.
             $parser = new parser();
-            $value = $parser->evaluate($match['expressionwrapper'], $this->flowenginestep->get_variables());
+            $value = $parser->evaluate_or_fail($match['expressionwrapper'], $this->flowenginestep->get_variables());
 
             // If the expression cannot be evaluated, then the query fragment is ignored entirely.
             if ($match['expressionwrapper'] === $value) {

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -31,6 +31,8 @@ use tool_dataflows\parser;
  */
 class reader_sql extends reader_step {
 
+    private $flowenginestep;
+
     /**
      * Return the definition of the fields available in this form.
      *
@@ -52,6 +54,7 @@ class reader_sql extends reader_step {
      * @throws \moodle_exception
      */
     public function get_iterator(flow_engine_step $step): iterator {
+        $this->flowenginestep = $step;
         $query = $this->construct_query($step);
         return new class($step, $query) extends php_iterator {
 
@@ -99,8 +102,9 @@ class reader_sql extends reader_step {
             $parser = new parser();
             $value = $parser->evaluate_or_fail($match['expressionwrapper'], $this->flowenginestep->get_variables());
 
-            // If the expression cannot be evaluated, then the query fragment is ignored entirely.
-            if ($match['expressionwrapper'] === $value) {
+            // If the expression cannot be evaluated (or evaluates to an empty
+            // string), then the query fragment is ignored entirely.
+            if ($match['expressionwrapper'] === $value || $value === '') {
                 $finalsql = str_replace($match['fragmentwrapper'], '', $finalsql);
                 continue;
             }

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -31,8 +31,6 @@ use tool_dataflows\parser;
  */
 class reader_sql extends reader_step {
 
-    private $flowenginestep;
-
     /**
      * Return the definition of the fields available in this form.
      *
@@ -54,8 +52,8 @@ class reader_sql extends reader_step {
      * @throws \moodle_exception
      */
     public function get_iterator(flow_engine_step $step): iterator {
-        $this->flowenginestep = $step;
-        $query = $this->construct_query($step);
+        $this->enginestep = $step;
+        $query = $this->construct_query();
         return new class($step, $query) extends php_iterator {
 
             public function __construct(flow_engine_step $step, string $query) {
@@ -78,7 +76,7 @@ class reader_sql extends reader_step {
      * @throws \moodle_exception
      */
     protected function construct_query(): string {
-        $config = $this->flowenginestep->stepdef->config;
+        $config = $this->enginestep->stepdef->config;
 
         $rawsql = $config->sql;
         // Parses the query, removing any optional blocks which cannot be resolved by the containing expression.
@@ -100,7 +98,7 @@ class reader_sql extends reader_step {
             // Check expression evaluation using the current config object
             // first, then failing that, target the dataflow variables.
             $parser = new parser();
-            $value = $parser->evaluate_or_fail($match['expressionwrapper'], $this->flowenginestep->get_variables());
+            $value = $parser->evaluate_or_fail($match['expressionwrapper'], $this->enginestep->get_variables());
 
             // If the expression cannot be evaluated (or evaluates to an empty
             // string), then the query fragment is ignored entirely.
@@ -169,11 +167,11 @@ class reader_sql extends reader_step {
      */
     public function execute($value) {
         // Check the config for the counterfield.
-        $config = $this->flowenginestep->stepdef->config;
+        $config = $this->enginestep->stepdef->config;
         $counterfield = $config->counterfield ?? null;
         if (isset($counterfield)) {
             // Updates the countervalue based on the current counterfield value.
-            $this->flowenginestep->set_var('countervalue', $value->{$counterfield});
+            $this->enginestep->set_var('countervalue', $value->{$counterfield});
         }
 
         return $value;

--- a/classes/parser.php
+++ b/classes/parser.php
@@ -41,6 +41,28 @@ class parser {
      * @return     mixed
      */
     public function evaluate(string $expression, array $variables) {
+        return $this->internal_evaluator($expression, $variables, false);
+    }
+
+    /**
+     * Evalulates the expression provided and on fail will throw an exception.
+     *
+     * @param      string $expression
+     * @param      array $variables containing anything relevant to the evaluation of the result
+     * @return     mixed
+     */
+    public function evaluate_or_fail(string $expression, array $variables) {
+        return $this->internal_evaluator($expression, $variables, true);
+    }
+
+    /**
+     * Evalulates the expressions in the string provided.
+     *
+     * @param      string $expression
+     * @param      array $variables containing anything relevant to the evaluation of the result
+     * @return     mixed
+     */
+    private function internal_evaluator(string $expression, array $variables, $throwonfail) {
         $evaluatedexpression = $expression;
         preg_match_all('/\${{(?<expression>.*)}}/mU', $expression, $matches, PREG_SET_ORDER);
         if (!empty($matches)) {
@@ -56,7 +78,10 @@ class parser {
                     // Set the evalulated expression to the one that passed through the expression language.
                     $evaluatedexpression = str_replace($match[0], $result, $evaluatedexpression);
                 } catch (\Exception $e) {
-                    mtrace("Issue parsing {$match[0]} - {$e->getMessage()}");
+                    if ($throwonfail) {
+                        mtrace("Issue parsing {$match[0]} - {$e->getMessage()}");
+                        throw $e;
+                    }
                     continue;
                 }
             }

--- a/classes/step.php
+++ b/classes/step.php
@@ -458,4 +458,21 @@ class step extends persistent {
 
         return $dotscript;
     }
+
+    /**
+     * Updates the value stored in the step's config
+     *
+     * @param      string name or path to name of field e.g. 'some.nested.fieldname'
+     * @param      mixed value
+     */
+    public function set_var($name, $value) {
+        // Grabs the current config.
+        $config = $this->config;
+
+        // Updates the field in question.
+        $config->{$name} = $value;
+
+        // Updates the stored config.
+        $this->config = Yaml::dump((array) $config);
+    }
 }

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -146,3 +146,7 @@ $string['writer_stream:format_help'] = 'The output format of the contents writte
 
 // Reader SQL.
 $string['reader_sql:sql'] = 'SQL';
+$string['reader_sql:counterfield'] = 'Counter field';
+$string['reader_sql:counterfield_help'] = 'Field in which the counter value is derived from. For example, the userid field in user related query';
+$string['reader_sql:countervalue'] = 'Counter Value';
+$string['reader_sql:countervalue_help'] = 'Current value from the counter field';

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -91,6 +91,7 @@ $string['new_step'] = 'New step';
 $string['stepchooser'] = 'Step chooser';
 
 // Warnings / Errors.
+$string['variablefieldnotexpected'] = 'The field \'{$a->field}\' cannot be set as it is not an expected field for step type \'{$a->steptype}\'.';
 $string['invalidyaml'] = 'The content provided is invalid YAML.';
 $string['hassideeffect'] = 'Has a side effect';
 $string['nodataflowfile'] = 'No dataflow file found.';

--- a/tests/local/execution/tool_dataflows_basic_execution_test.php
+++ b/tests/local/execution/tool_dataflows_basic_execution_test.php
@@ -56,7 +56,7 @@ class tool_dataflows_basic_execution_test extends \advanced_testcase {
      * @throws \moodle_exception
      */
     public function test_in_and_out() {
-        // Crate the dataflow.
+        // Create the dataflow.
         $dataflow = new dataflow();
         $dataflow->name = 'two-step';
         $dataflow->save();

--- a/tests/tool_dataflows_sql_reader_test.php
+++ b/tests/tool_dataflows_sql_reader_test.php
@@ -120,10 +120,6 @@ class tool_dataflows_sql_reader_test extends \advanced_testcase {
      */
     public function test_expressions_within_a_run() {
         global $DB;
-        // The gist:
-        // - Read some records,
-        // - ensure the counter (iterator checkpoint) is set after each iteration, based on & if the field is provided.
-        // - Perform the run again, and this time, expect the record to start from the next value, according to the SQL defined.
 
         // Insert test records.
         $template = ['plugin' => '--phantom_plugin--'];
@@ -134,11 +130,14 @@ class tool_dataflows_sql_reader_test extends \advanced_testcase {
             ]);
             $DB->insert_record('config_plugins', (object) $input);
         }
+
+        // Prepare query, with an optional fragment which is included if the
+        // expression field is present. Otherwise it is skipped.
         $sql = 'SELECT *
                   FROM {config_plugins}
                  WHERE plugin = \'' . $template['plugin'] . '\'
-                 [[ AND CAST(value as int) > ${{countervalue}} ]]
-                 ORDER BY CAST(value as int) ASC
+                [[ AND CAST(value as int) > ${{countervalue}} ]]
+              ORDER BY CAST(value as int) ASC
                  LIMIT 3';
 
         // Create the dataflow.


### PR DESCRIPTION
- feat: add optional query fragments and variable setting for reader_sql
- feat: add expressions support to the dataflow engine and sql reader
- fix: reduce noisy expression parsing by splitting methods
- test: fix/add tests and skip empty evaluated sql expressions

Related to #5 