### PR TITLE
feat: add global and dataflow level variable setting

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -76,8 +76,11 @@ class dataflow extends persistent {
      * @return     array of variables typically passed to the expression parser
      */
     public function get_variables(): array {
+        $globalconfig = Yaml::parse(get_config('tool_dataflows', 'config'), Yaml::PARSE_OBJECT_FOR_MAP) ?: new \stdClass;
+
         // Test reading a value directly.
         $variables = [
+            'global' => $globalconfig,
             'env' => (object) [
                 'DATAFLOW_ID' => $this->id,
                 'DATAFLOW_RUN_NUMBER' => 0,
@@ -491,5 +494,22 @@ class dataflow extends persistent {
         }
 
         return $yaml;
+    }
+
+    /**
+     * Updates the value stored in the dataflow's config
+     *
+     * @param  string name or path to name of field e.g. 'some.nested.fieldname'
+     * @param  mixed value
+     */
+    public function set_var($name, $value) {
+        // Grabs the current config.
+        $config = $this->config;
+
+        // Updates the field in question.
+        $config->{$name} = $value;
+
+        // Updates the stored config.
+        $this->config = Yaml::dump((array) $config);
     }
 }

--- a/classes/local/execution/engine_step.php
+++ b/classes/local/execution/engine_step.php
@@ -201,7 +201,7 @@ abstract class engine_step {
         // TODO: implement.
 
         $previous = $this->stepdef->config->{$name};
-        $this->log("Setting '$name' to '$value' (from '{$previous}')");
+        $this->log("Setting step '$name' to '$value' (from '{$previous}')");
         $this->stepdef->set_var($name, $value);
 
         // Persists the variable to the dataflow step config.
@@ -209,5 +209,30 @@ abstract class engine_step {
         if (!$this->engine->isdryrun) {
             $this->stepdef->save();
         }
+    }
+
+    /**
+     * Sets a variable at the dataflow level
+     *
+     * This is a proxy to the engine's implementation.
+     * TODO: add instance support.
+     *
+     * @param  string name of the field
+     * @param  mixed value
+     */
+    public function set_dataflow_var($name, $value) {
+        $this->engine->set_dataflow_var($name, $value);
+    }
+
+    /**
+     * Sets a variable at the global (plugin) level
+     *
+     * This is a proxy to the engine's implementation.
+     *
+     * @param  string name of the field
+     * @param  mixed value
+     */
+    public function set_global_var($name, $value) {
+        $this->engine->set_global_var($name, $value);
     }
 }

--- a/tests/local/execution/array_in_type.php
+++ b/tests/local/execution/array_in_type.php
@@ -36,7 +36,7 @@ class array_in_type extends reader_step {
     /** @var int[] number of input flows (min, max), zero for readers. */
     protected $inputflows = [0, 0];
 
-    /** @var array The source. Place dat here before use. */
+    /** @var array The source. Place data here before use. */
     public static $source = [];
 
     public function get_iterator(flow_engine_step $step): iterator {

--- a/tests/local/execution/reader_sql_variable_setter.php
+++ b/tests/local/execution/reader_sql_variable_setter.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\execution;
+
+use tool_dataflows\local\step\reader_sql;
+
+/**
+ * Test reader step type that during execution will write to all the scopes for testing purposes
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class reader_sql_variable_setter extends reader_sql {
+
+    /** @var string dataflow variable to set */
+    public static $dataflowvar;
+
+    /** @var string global (plugin scope) variable to set */
+    public static $globalvar;
+
+    /**
+     * Return the definition of the fields available in this form.
+     *
+     * @return array
+     */
+    protected static function form_define_fields(): array {
+        return array_merge(
+            parent::form_define_fields(),
+            [
+                'localvar' => ['type' => PARAM_TEXT]
+            ]
+        );
+    }
+
+    public function execute($input) {
+        parent::execute($input);
+        // Updates a dataflow scoped variable.
+        $this->enginestep->set_dataflow_var('dataflowvar', self::$dataflowvar);
+        // Updates a global (plugin scoped) variable.
+        $this->enginestep->set_global_var('globalvar', self::$globalvar);
+        return $input;
+    }
+}


### PR DESCRIPTION
- add supporting tests
- reader_sql_variable_setter class contains an example of how it can be set, and the tool_dataflows_variables_test test class shows how it can be retrieved (directly) and via an expression.

Resolves #5
