### PR TITLE
fix: reader_sql where the counterfield was referced even if it was empty

### DIFF
--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -169,7 +169,7 @@ class reader_sql extends reader_step {
         // Check the config for the counterfield.
         $config = $this->enginestep->stepdef->config;
         $counterfield = $config->counterfield ?? null;
-        if (isset($counterfield)) {
+        if (!empty($counterfield)) {
             // Updates the countervalue based on the current counterfield value.
             $this->enginestep->set_var('countervalue', $value->{$counterfield});
         }


### PR DESCRIPTION
Resolves #178

Tested against, and it will also Resolves #177
