### PR TITLE
Issue #190: Enhance abort logging

### DIFF
--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -251,7 +251,7 @@ class engine {
             $enginestep->abort();
         }
         $this->status = self::STATUS_ABORTED;
-        $this->log('Aborted');
+        $this->log('Aborted: ' . $exception->getMessage());
         // TODO: We may want to make this the responsibility of the caller.
         throw $exception;
     }

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -151,6 +151,10 @@ $string['invalid_config'] = 'Invalid configuration';
 $string['non_reader_steps_must_have_flow_upstreams'] = 'Non reader steps must have at least one flow step dependency.';
 $string['format_not_supported'] = 'The format \'{$a}\' is not supported.';
 
+// Stream errors.
+$string['writer_stream:failed_to_open_stream'] = 'Failed to open stream "{$a}".';
+$string['writer_stream:failed_to_write_stream'] = 'Failed to write to stream "{$a}".';
+
 // Capabilities.
 $string['dataflows:managedataflows'] = 'Create and configure dataflows';
 $string['dataflows:exportdataflowhistory'] = 'Download / export history of dataflows';


### PR DESCRIPTION
Resolves #190 

Add exception message to engine abort log.
Add log calls to writer_stream when errors occur.
Add extra checks to writer_stream when errors occur.