### PR TITLE
Issue #188: Create logging contexts

### DIFF
--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -262,7 +262,7 @@ class engine {
      * @param string $message
      */
     public function log(string $message) {
-        mtrace('Engine \'' . $this->name . '\': ' . $message);
+        (new logging_context($this))->log($message);
     }
 
     /**

--- a/classes/local/execution/engine_step.php
+++ b/classes/local/execution/engine_step.php
@@ -171,7 +171,7 @@ abstract class engine_step {
      * @param string $message
      */
     public function log(string $message) {
-        mtrace('Engine \'' . $this->engine->name . '\', step \'' . $this->name . '\': ' . $message);
+        (new logging_context($this))->log($message);
     }
 
     /**

--- a/classes/local/execution/logging_context.php
+++ b/classes/local/execution/logging_context.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\execution;
+
+/**
+ * An environment for logging information about dataflow execution.
+ *
+ * @package
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class logging_context {
+    protected $engine = null;
+    protected $enginestep = null;
+
+    public function __construct($object) {
+        if ($object instanceof engine_step) {
+            $this->enginestep = $object;
+            $this->engine = $object->engine;
+        } else if ($object instanceof engine) {
+            $this->engine = $object;
+        } else {
+            throw new \moodle_exception('Unknown context object');
+        }
+    }
+
+    public function log($message) {
+        $logstr = 'Engine "' . $this->engine->name . '"';
+        if (!is_null($this->enginestep)) {
+            $logstr .= ', step "' . $this->enginestep->name . '"';
+        }
+        $logstr .= ': ' . $message;
+        mtrace($logstr);
+    }
+}


### PR DESCRIPTION
Resolves #188 
Add class logging_context
Encapsulate logic for creating a log inside the context object.

Added a context object for use in logging. This encapsulates the logging logic, separating it from other classes. This obejct can be easily expanded when needed.