### PR TITLE
fix: yaml parsing for saving/imports to allow for multiline literal view

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -492,7 +492,7 @@ class dataflow extends persistent {
      */
     public function import(array $yaml) {
         $this->name = $yaml['name'] ?? '';
-        $this->config = isset($yaml['config']) ? Yaml::dump($yaml['config']) : '';
+        $this->config = isset($yaml['config']) ? Yaml::dump($yaml['config'], 2, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK) : '';
         $this->save();
 
         // Import any provided steps.
@@ -559,6 +559,6 @@ class dataflow extends persistent {
         $config->{$name} = $value;
 
         // Updates the stored config.
-        $this->config = Yaml::dump((array) $config);
+        $this->config = Yaml::dump((array) $config, 2, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
     }
 }

--- a/classes/exportable.php
+++ b/classes/exportable.php
@@ -45,7 +45,7 @@ trait exportable {
         $inline = 4;
         // 2 spaces per level of indentation.
         $indent = 2;
-        $contents = Yaml::dump($this->get_export_data(), $inline, $indent);
+        $contents = Yaml::dump($this->get_export_data(), $inline, $indent, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
 
         return $contents;
     }

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -284,6 +284,8 @@ abstract class base_step {
             }
 
             $config[$fieldname] = $data->{$datafield};
+            // Use '\n' instead of '\r\n' for new lines to allow YAML multi-line literals to work.
+            $config[$fieldname] = str_replace("\r\n", "\n", $config[$fieldname]);
             unset($data->{$datafield});
         }
 
@@ -292,7 +294,7 @@ abstract class base_step {
             $inline = 4;
             // 2 spaces per level of indentation.
             $indent = 2;
-            $data->config = Yaml::dump($config, $inline, $indent);
+            $data->config = Yaml::dump($config, $inline, $indent, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
         }
 
         return $data;

--- a/classes/step.php
+++ b/classes/step.php
@@ -336,7 +336,7 @@ class step extends persistent {
         $this->alias = $stepdata['id'];
 
         // Set the config as a valid YAML string.
-        $this->config = isset($stepdata['config']) ? Yaml::dump($stepdata['config']) : '';
+        $this->config = isset($stepdata['config']) ? Yaml::dump($stepdata['config'], 2, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK) : '';
 
         // Set up the dependencies, connected to each other via their step aliases.
         if (!empty($stepdata['depends_on'])) {
@@ -677,6 +677,6 @@ class step extends persistent {
         $config->{$name} = $value;
 
         // Updates the stored config.
-        $this->config = Yaml::dump((array) $config);
+        $this->config = Yaml::dump((array) $config, 2, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
     }
 }


### PR DESCRIPTION
Example of result after:
![image](https://user-images.githubusercontent.com/9924643/173998310-e5609d6f-30a4-40be-8619-8f0f559a6737.png)

Can probably refactor to pass through a helper function which applies the defaults indentation, spacing levels and multiline flags. But this was the quickest in place option for now.

Resolves #208


