### PR TITLE
Issue #204: Cleanup step type classes.

### DIFF
--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -129,8 +129,8 @@ class engine {
         // Create engine steps for each step in the dataflow.
         foreach ($dataflow->steps as $stepdef) {
             $classname = $stepdef->type;
-            $steptype = new $classname();
-            $this->enginesteps[$stepdef->id] = $steptype->get_engine_step($this, $stepdef);
+            $steptype = new $classname($stepdef, $this);
+            $this->enginesteps[$stepdef->id] = $steptype->get_engine_step();
         }
 
         // Create the links between engine step.
@@ -181,11 +181,11 @@ class engine {
         $flowcaps = 0;
         foreach ($this->enginesteps as $enginestep) {
             if ($enginestep->is_flow() && count($enginestep->downstreams) == 0) {
-                $steptype = new flow_cap();
                 $step = new \tool_dataflows\step();
+                $steptype = new flow_cap($step, $this);
                 $flowcaps++;
                 $step->name = "flowcap-{$flowcaps}";
-                $flowcap = $steptype->get_engine_step($this, $step);
+                $flowcap = $steptype->get_engine_step();
                 $this->flowcaps[] = $flowcap;
                 $enginestep->downstreams['puller'] = $flowcap;
                 $flowcap->upstreams[$enginestep->id] = $enginestep;

--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -35,10 +35,9 @@ class connector_curl extends connector_step {
      *
      * TODO: This will perform a curl call
      *
-     * @param engine_step $enginestep the execution engine parent step context
      * @return bool Returns true if successful, false otherwise.
      */
-    public function execute(engine_step $enginestep): bool {
+    public function execute(): bool {
         // TODO: Implement.
         return true;
     }

--- a/classes/local/step/connector_debugging.php
+++ b/classes/local/step/connector_debugging.php
@@ -32,10 +32,9 @@ class connector_debugging extends connector_step {
      *
      * This will logs the input via debugging and passes the input value as-is to the output.
      *
-     * @param engine_step $enginestep the execution engine parent step context
      * @return bool Returns true if successful, false otherwise.
      */
-    public function execute(engine_step $enginestep): bool {
+    public function execute(): bool {
         // TODO: Reach in and output the result of an expression via a debugging call.
         return true;
     }

--- a/classes/local/step/connector_s3.php
+++ b/classes/local/step/connector_s3.php
@@ -52,13 +52,11 @@ class connector_s3 extends connector_step {
      *
      * This will take the input and perform S3 interaction functions.
      *
-     * @param engine_step $enginestep the execution engine parent step context
      * @return bool Returns true if successful, false otherwise.
      */
-    public function execute(engine_step $enginestep): bool {
+    public function execute(): bool {
         global $CFG;
         // Engine step contains the execution context, configuration, variables etc.
-        $this->enginestep = $enginestep;
 
         try {
             // Only autoload the AWS SDK at runtime.

--- a/classes/local/step/connector_step.php
+++ b/classes/local/step/connector_step.php
@@ -40,10 +40,9 @@ abstract class connector_step extends base_step {
     /**
      * Perform the task required by this connector.
      *
-     * @param engine_step $enginestep the execution engine parent step context
      * @return bool Returns true if successful, false otherwise.
      */
-    abstract public function execute(engine_step $enginestep): bool;
+    abstract public function execute(): bool;
 
     /**
      * {@inheritdoc}
@@ -58,12 +57,10 @@ abstract class connector_step extends base_step {
      * This should be sufficient for most cases. Override this function if needed.
      *
      * @param engine $engine
-     * @param \tool_dataflows\step $stepdef
      * @return engine_step
      */
-    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        $this->enginestep = new connector_engine_step($engine, $stepdef, $this);
-        return $this->enginestep;
+    protected function generate_engine_step(engine $engine): engine_step {
+        return new connector_engine_step($engine, $this->stepdef, $this);
     }
 
     /**

--- a/classes/local/step/flow_cap.php
+++ b/classes/local/step/flow_cap.php
@@ -34,10 +34,9 @@ final class flow_cap extends flow_step {
      * Generates an engine step for this type.
      *
      * @param engine $engine
-     * @param \tool_dataflows\step $stepdef
      * @return engine_step
      */
-    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        return new engine_flow_cap($engine, $stepdef, $this);
+    protected function generate_engine_step(engine $engine): engine_step {
+        return new engine_flow_cap($engine, $this->stepdef, $this);
     }
 }

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -63,12 +63,10 @@ abstract class flow_step extends base_step {
      * This should be sufficient for most cases. Override this function if needed.
      *
      * @param engine $engine
-     * @param \tool_dataflows\step $stepdef
      * @return engine_step
      */
-    public function get_engine_step(engine $engine, \tool_dataflows\step $stepdef): engine_step {
-        $this->enginestep = new flow_engine_step($engine, $stepdef, $this);
-        return $this->enginestep;
+    protected function generate_engine_step(engine $engine): engine_step {
+        return new flow_engine_step($engine, $this->stepdef, $this);
     }
 
     /**
@@ -77,13 +75,13 @@ abstract class flow_step extends base_step {
      * @param flow_engine_step $step
      * @return iterator
      */
-    public function get_iterator(flow_engine_step $step): iterator {
+    public function get_iterator(): iterator {
         // Default is to simply map.
-        $upstream = current($step->upstreams);
+        $upstream = current($this->enginestep->upstreams);
         if ($upstream === false || !$upstream->is_flow()) {
             throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
         }
-        return new map_iterator($step, $upstream->iterator);
+        return new map_iterator($this->enginestep, $upstream->iterator);
     }
 
     /**

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -47,13 +47,12 @@ class reader_sql extends reader_step {
     /**
      * Get the iterator for the step, based on configurations.
      *
-     * @param flow_engine_step $step
      * @return iterator
      * @throws \moodle_exception
      */
-    public function get_iterator(flow_engine_step $step): iterator {
+    public function get_iterator(): iterator {
         $query = $this->construct_query();
-        return new class($step, $query) extends php_iterator {
+        return new class($this->enginestep, $query) extends php_iterator {
 
             public function __construct(flow_engine_step $step, string $query) {
                 global $DB;

--- a/classes/local/step/reader_step.php
+++ b/classes/local/step/reader_step.php
@@ -39,16 +39,15 @@ abstract class reader_step extends flow_step {
     /**
      * Get the iterator for the step, based on configurations.
      *
-     * @param flow_engine_step $step
      * @return iterator
      */
-    public function get_iterator(flow_engine_step $step): iterator {
+    public function get_iterator(): iterator {
         // Default is to simply map.
-        $upstream = current($step->upstreams);
+        $upstream = current($this->enginestep->upstreams);
         if ($upstream === false || !$upstream->is_flow()) {
             throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
         }
-        return new map_iterator($step, $upstream->iterator);
+        return new map_iterator($this->enginestep, $upstream->iterator);
     }
 
     /**

--- a/classes/local/step/trigger_cron.php
+++ b/classes/local/step/trigger_cron.php
@@ -81,14 +81,14 @@ class trigger_cron extends trigger_step {
      *
      * @param step $stepdef
      */
-    public function on_save(step $stepdef) {
+    public function on_save() {
         $newtime = scheduler::determine_next_scheduled_time(
-            $stepdef->config->timestr,
-            scheduler::get_last_scheduled_time($stepdef->dataflowid) ?: time()
+            $this->stepdef->config->timestr,
+            scheduler::get_last_scheduled_time($this->stepdef->dataflowid) ?: time()
         );
 
         scheduler::update_next_scheduled_time(
-            $stepdef->dataflowid,
+            $this->stepdef->dataflowid,
             $newtime
         );
     }
@@ -98,10 +98,10 @@ class trigger_cron extends trigger_step {
      *
      * @param step $stepdef
      */
-    public function on_delete(step $stepdef) {
+    public function on_delete() {
         global $DB;
 
-        $DB->delete_records(scheduler::TABLE, ['dataflowid' => $stepdef->dataflowid]);
+        $DB->delete_records(scheduler::TABLE, ['dataflowid' => $this->stepdef->dataflowid]);
     }
 
     /**

--- a/classes/local/step/trigger_step.php
+++ b/classes/local/step/trigger_step.php
@@ -49,26 +49,24 @@ abstract class trigger_step extends connector_step {
      * example if the event doesn't contain the expected fields, then it would
      * return false potentially.
      *
-     * @param engine_step $enginestep the execution engine parent step context
      * @return true for now, since this will be configured differently per step
      */
-    public function execute(engine_step $enginestep): bool {
+    public function execute(): bool {
         return true;
     }
 
     /**
      * Get the iterator for the step, based on configurations.
      *
-     * @param flow_engine_step $step
      * @return iterator
      */
-    public function get_iterator(flow_engine_step $step): iterator {
+    public function get_iterator(): iterator {
         // Default is to simply map.
-        $upstream = current($step->upstreams);
+        $upstream = current($this->enginestep->upstreams);
         if ($upstream === false || !$upstream->is_flow()) {
             throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
         }
-        return new map_iterator($step, $upstream->iterator);
+        return new map_iterator($this->enginestep, $upstream->iterator);
     }
 
     /**

--- a/classes/local/step/writer_step.php
+++ b/classes/local/step/writer_step.php
@@ -48,13 +48,13 @@ abstract class writer_step extends flow_step {
      * @param flow_engine_step $step
      * @return iterator
      */
-    public function get_iterator(flow_engine_step $step): iterator {
+    public function get_iterator(): iterator {
         // Default is to simply map.
-        $upstream = current($step->upstreams);
+        $upstream = current($this->enginestep->upstreams);
         if ($upstream === false || !$upstream->is_flow()) {
             throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
         }
-        return new map_iterator($step, $upstream->iterator);
+        return new map_iterator($this->enginestep, $upstream->iterator);
     }
 
     /**

--- a/classes/local/step/writer_stream.php
+++ b/classes/local/step/writer_stream.php
@@ -72,26 +72,25 @@ class writer_stream extends writer_step {
     /**
      * Get the iterator for the step, based on configurations.
      *
-     * @param flow_engine_step $step
      * @return iterator
      */
-    public function get_iterator(flow_engine_step $step): iterator {
-        $upstream = current($step->upstreams);
+    public function get_iterator(): iterator {
+        $upstream = current($this->enginestep->upstreams);
         if ($upstream === false || !$upstream->is_flow()) {
             throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
         }
 
-        $config = $step->stepdef->config;
+        $config = $this->enginestep->stepdef->config;
 
         // We make no output in a dry run.
-        if ($step->engine->isdryrun) {
-            return new map_iterator($step, $upstream->iterator);
+        if ($this->enginestep->engine->isdryrun) {
+            return new map_iterator($this->enginestep, $upstream->iterator);
         }
 
         /*
          * Iterator class to write out to the stream.
          */
-        return new class($step, $config->streamname, $config->format, $upstream->iterator) extends map_iterator {
+        return new class($this->enginestep, $config->streamname, $config->format, $upstream->iterator) extends map_iterator {
             /** @var resource stream handle. */
             private $handle;
             /** @var string name of the stream. */

--- a/classes/step.php
+++ b/classes/step.php
@@ -145,7 +145,7 @@ class step extends persistent {
      */
     public function get_steptype() {
         $classname = $this->type;
-        return new $classname();
+        return new $classname($this);
     }
 
     /**
@@ -314,7 +314,7 @@ class step extends persistent {
         // Update the local dependencies to the database.
         $this->update_depends_on();
 
-        $this->steptype->on_save($this);
+        $this->steptype->on_save();
 
         return $this;
     }
@@ -408,7 +408,7 @@ class step extends persistent {
         $DB->delete_records('tool_dataflows_step_depends', ['stepid' => $this->id]);
         $DB->delete_records('tool_dataflows_step_depends', ['dependson' => $this->id]);
 
-        $this->steptype->on_delete($this);
+        $this->steptype->on_delete();
 
     }
 
@@ -499,7 +499,7 @@ class step extends persistent {
     /**
      * Validates links, either input or output.
      *
-     * @param array $deps Dependencies or dependents, depending on $inputoutput.
+     * @param array $deps List of database records for dependencies or dependents, depending on $inputoutput.
      * @param string $inputoutput 'input' or 'output'.
      * @return array|bool true if the validataion suceeded. An array or errors otherwise.
      * @throws \coding_exception

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -161,6 +161,7 @@ $string['running_disabled_dataflow'] = 'Trying to run a disabled dataflow.';
 $string['running_invalid_dataflow'] = 'Trying to run an invalid dataflow.';
 $string['change_state_after_concluded'] = 'Attempting to change the status of a dataflow engine after it has concluded.';
 $string['bad_status'] = 'Bad status, had "{$a->status}", expected "{$a->expected}"';
+$string['must_have_a_step_def_defined'] = 'If an engine is passed as a parameter, a step definition must alse be passed.';
 
 // Stream errors.
 $string['writer_stream:failed_to_open_stream'] = 'Failed to open stream "{$a}".';

--- a/tests/local/execution/array_in_type.php
+++ b/tests/local/execution/array_in_type.php
@@ -39,8 +39,8 @@ class array_in_type extends reader_step {
     /** @var array The source. Place data here before use. */
     public static $source = [];
 
-    public function get_iterator(flow_engine_step $step): iterator {
-        return new php_iterator($step, new \ArrayIterator(self::$source));
+    public function get_iterator(): iterator {
+        return new php_iterator($this->enginestep, new \ArrayIterator(self::$source));
     }
 
     public function execute($input) {

--- a/tests/local/execution/array_out_type.php
+++ b/tests/local/execution/array_out_type.php
@@ -35,9 +35,9 @@ class array_out_type extends writer_step {
     /** @var array The output array that the dat is written into. Make sure it is empty before use. */
     public static $dest = [];
 
-    public function get_iterator(flow_engine_step $step): iterator {
-        $input = current($step->upstreams)->iterator;
-        return new map_iterator($step, $input);
+    public function get_iterator(): iterator {
+        $input = current($this->enginestep->upstreams)->iterator;
+        return new map_iterator($this->enginestep, $input);
     }
 
     public function execute($input) {

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022061700;
-$plugin->release = 2022061700;
+$plugin->version = 2022062000;
+$plugin->release = 2022062000;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
Resolves #204 

Also included cleanup for the $stepdef member.

Refactor to have stepdef and enginestep members set in the constructor of base_step.
Remove stepdef and enginestep from parameter list of all functions in step type classes.
Refactor step::get_steptype() to pass itself to the constuctor of the steptype class.
Refactor engine to pass the stepdef and itself to the constructor of the steptype, in order to generate the engine.
Change get_engine_step() to just return the engien step.
Add generate_engine_step() to generate to engine step.
Refactor all step type classes to call generate_engien_step instead of get_engine_step.