### PR TITLE
feat: add .txt as a valid file to import, with contents expected in yaml

### DIFF
--- a/classes/import_form.php
+++ b/classes/import_form.php
@@ -45,7 +45,7 @@ class import_form extends \moodleform {
             'userfile',
             get_string('dataflow_file', 'tool_dataflows'),
             null,
-            ['maxbytes' => 256000, 'accepted_types' => ['.yml', '.yaml']]
+            ['maxbytes' => 256000, 'accepted_types' => ['.yml', '.yaml', '.txt']]
         );
         $mform->addRule('userfile', get_string('required'), 'required');
 


### PR DESCRIPTION
This is to avoid the need to rename the file when uploaded to and from places like GitHub

Resolves #232

You can use this file to test if the new changes work:

[example-dataflow.yml.txt](https://github.com/catalyst/moodle-tool_dataflows/files/8972827/example-dataflow.yml.txt)


