### PR TITLE
170 ui for runs

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -370,6 +370,18 @@ class dataflow extends persistent {
     }
 
     /**
+     * Returns a list of runs
+     *
+     * @param   int $limit number of runs to fetch (most recent)
+     * @return  array of run persistents
+     */
+    public function get_runs($limit): array {
+        global $DB;
+        $records = $DB->get_records('tool_dataflows_runs', ['dataflowid' => $this->id], 'id DESC', '*', 0, $limit);
+        return array_reverse($records);
+    }
+
+    /**
      * Returns a list of step (persistent models)
      *
      * @return     \stdClass array of step models, keyed by their alias, ordered by their possible execution order

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -438,6 +438,11 @@ class engine {
         }
         $this->status = $status;
 
+        // Updates the run's state when the engine status changes.
+        if (isset($this->run)) {
+            $this->run->snapshot($this->status);
+        }
+
         // Record the timestamp of the state change against the dataflow persistent,
         // which exposes this info through its variables.
         $this->dataflow->set_state_timestamp($status, microtime(true));

--- a/classes/run.php
+++ b/classes/run.php
@@ -40,9 +40,9 @@ class run extends persistent {
             'name' => ['type' => PARAM_TEXT],
             'userid' => ['type' => PARAM_INT],
             'status' => ['type' => PARAM_TEXT],
-            'timestarted' => ['type' => PARAM_INT, 'default' => 0],
-            'timepaused' => ['type' => PARAM_INT, 'default' => 0],
-            'timefinished' => ['type' => PARAM_INT, 'default' => 0],
+            'timestarted' => ['type' => PARAM_FLOAT, 'default' => 0],
+            'timepaused' => ['type' => PARAM_FLOAT, 'default' => 0],
+            'timefinished' => ['type' => PARAM_FLOAT, 'default' => 0],
             'startstate' => ['type' => PARAM_TEXT, 'default' => ''],
             'currentstate' => ['type' => PARAM_TEXT, 'default' => ''],
             'endstate' => ['type' => PARAM_TEXT, 'default' => ''],
@@ -88,6 +88,10 @@ class run extends persistent {
      */
     public function initialise(string $status, string $startstate) {
         global $DB, $USER;
+
+        // Sets the time intialised.
+        $this->timestarted = microtime(true);
+
         // If this run is based on current settings (default behaviour until
         // re-run support is added), always increment the run counter by 1 (as a
         // whole number).
@@ -115,9 +119,14 @@ class run extends persistent {
      * @param  string $status the engine's status
      * @param  string $currentstate the yaml string representation of the state of the dataflow
      */
-    public function snapshot(string $status, string $currentstate) {
+    public function snapshot(string $status, ?string $currentstate = null) {
         $this->status = $status;
-        $this->currentstate = $currentstate;
+
+        // Updates the state of the current run if provided.
+        if (isset($currentstate)) {
+            $this->currentstate = $currentstate;
+        }
+
         // TODO: Determine how often this is updated to the DB (per step by
         // default), or only on finalise / shutdown, as this is likely to be
         // updated VERY often.
@@ -131,6 +140,7 @@ class run extends persistent {
      * @param  string $endstate the yaml string representation of the state of the dataflow
      */
     public function finalise(string $status, string $endstate) {
+        $this->timefinished = microtime(true);
         $this->endstate = $endstate;
         $this->status = $status;
         $this->save();

--- a/classes/runs_table.php
+++ b/classes/runs_table.php
@@ -112,9 +112,7 @@ class runs_table extends \table_sql {
      * @return string
      */
     public function col_timestarted(\stdClass $record): string {
-        $defaulttimezone = date_default_timezone_get();
-        $formatteddate = date_format_string($record->timestarted, get_string('strftimedatetimeaccurate'), $defaulttimezone);
-        return $formatteddate;
+        return userdate($record->timestarted, get_string('strftimedatetimeaccurate'));
     }
 
     /**
@@ -124,9 +122,7 @@ class runs_table extends \table_sql {
      * @return string
      */
     public function col_timefinished(\stdClass $record): string {
-        $defaulttimezone = date_default_timezone_get();
-        $formatteddate = date_format_string($record->timefinished, get_string('strftimedatetimeaccurate'), $defaulttimezone);
-        return $formatteddate;
+        return userdate($record->timefinished, get_string('strftimedatetimeaccurate'));
     }
 
     /**

--- a/classes/runs_table.php
+++ b/classes/runs_table.php
@@ -1,0 +1,142 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+use tool_dataflows\local\execution\engine;
+
+/**
+ * Display a table runs for a particular dataflow.
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class runs_table extends \table_sql {
+
+    const COLUMNS = [
+        'name',
+        'userid',
+        'status',
+        'timestarted',
+        'timefinished',
+        'duration',
+    ];
+
+    const NOSORT_COLUMNS = [
+        'actions',
+    ];
+
+    /**
+     * Returns the columns defined for the table.
+     *
+     * @return string[]
+     */
+    protected function get_columns(): array {
+        $columns = self::COLUMNS;
+        return $columns;
+    }
+
+    /**
+     * Defines the columns for this table.
+     */
+    public function make_columns(): void {
+        $headers = [];
+        $columns = $this->get_columns();
+        foreach ($columns as $column) {
+            $headers[] = get_string('field_' . $column, 'tool_dataflows');
+        }
+        foreach (self::NOSORT_COLUMNS ?? [] as $column) {
+            $this->no_sorting($column);
+        }
+        $this->sortable(false, 'name', SORT_DESC);
+        $this->define_columns($columns);
+        $this->define_headers($headers);
+    }
+
+    /**
+     * Display the run name
+     *
+     * @param \stdClass $record
+     * @return string
+     */
+    public function col_name(\stdClass $record): string {
+        $url = new \moodle_url('/admin/tool/dataflows/view-run.php', ['id' => $record->id]);
+        $btn = \html_writer::tag('button', $record->name, ['class' => 'btn btn-run-default']);
+        return \html_writer::link($url, $btn);
+    }
+
+    /**
+     * Display the user who started it
+     *
+     * @param \stdClass $record
+     * @return string
+     */
+    public function col_userid(\stdClass $record): string {
+        $url = new \moodle_url('/user/profile.php', ['id' => $record->userid]);
+        $fullname = fullname($record);
+        return \html_writer::link($url, $fullname);
+    }
+
+    /**
+     * Display the status as a string
+     *
+     * @param \stdClass $record
+     * @return string
+     */
+    public function col_status(\stdClass $record): string {
+        if (is_null($record->status)) {
+            return '';
+        }
+        return get_string('engine_status:' . engine::STATUS_LABELS[$record->status], 'tool_dataflows');
+    }
+
+    /**
+     * Return the time started as a formatted datetime string
+     *
+     * @param \stdClass $record
+     * @return string
+     */
+    public function col_timestarted(\stdClass $record): string {
+        $defaulttimezone = date_default_timezone_get();
+        $formatteddate = date_format_string($record->timestarted, get_string('strftimedatetimeaccurate'), $defaulttimezone);
+        return $formatteddate;
+    }
+
+    /**
+     * Return the time finished as a formatted datetime string
+     *
+     * @param \stdClass $record
+     * @return string
+     */
+    public function col_timefinished(\stdClass $record): string {
+        $defaulttimezone = date_default_timezone_get();
+        $formatteddate = date_format_string($record->timefinished, get_string('strftimedatetimeaccurate'), $defaulttimezone);
+        return $formatteddate;
+    }
+
+    /**
+     * Return the duration in seconds of the run.
+     *
+     * @param \stdClass $record
+     * @return string
+     */
+    public function col_duration(\stdClass $record): string {
+        $totalsecs = number_format($record->timefinished - $record->timestarted, 4);
+        return format_time($totalsecs);
+    }
+}

--- a/classes/runs_table.php
+++ b/classes/runs_table.php
@@ -76,8 +76,8 @@ class runs_table extends \table_sql {
      */
     public function col_name(\stdClass $record): string {
         $url = new \moodle_url('/admin/tool/dataflows/view-run.php', ['id' => $record->id]);
-        $btn = \html_writer::tag('button', $record->name, ['class' => 'btn btn-run-default']);
-        return \html_writer::link($url, $btn);
+        $runstate = engine::STATUS_LABELS[$record->status];
+        return \html_writer::link($url, $record->name, ['class' => "btn btn-run-default run-state-{$runstate}"]);
     }
 
     /**

--- a/classes/runs_table.php
+++ b/classes/runs_table.php
@@ -132,7 +132,7 @@ class runs_table extends \table_sql {
      * @return string
      */
     public function col_duration(\stdClass $record): string {
-        $totalsecs = number_format($record->timefinished - $record->timestarted, 4);
+        $totalsecs = number_format($record->timefinished - $record->timestarted, 3);
         return format_time($totalsecs);
     }
 }

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -16,6 +16,7 @@
 
 namespace tool_dataflows;
 
+use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\step\base_step;
 
 /**
@@ -297,8 +298,8 @@ class visualiser {
         // Show up to the last 10 runs.
         foreach ($runs as $run) {
             $runurl = new \moodle_url('/admin/tool/dataflows/view-run.php', ['id' => $run->id]);
-            $runlabel = \html_writer::tag('button', $run->name, ['class' => 'btn btn-run-default']);
-            echo \html_writer::link($runurl, $runlabel);
+            $runstate = engine::STATUS_LABELS[$run->status];
+            echo \html_writer::link($runurl, $run->name, ['class' => "btn btn-run-default run-state-{$runstate}"]);
         }
 
         // Recent runs label (no recent, or recent runs to describe the list).

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -168,7 +168,7 @@ class visualiser {
         echo $output->footer();
     }
 
-    public static function display_steps_table(int $dataflowid, steps_table $table, \moodle_url $url, string $pageheading) {
+    public static function display_dataflows_view_page(int $dataflowid, steps_table $table, \moodle_url $url, string $pageheading) {
         global $PAGE;
 
         $output = $PAGE->get_renderer('tool_dataflows');
@@ -185,6 +185,9 @@ class visualiser {
         // Validate current dataflow, displaying any reason why the flow is not valid.
         $validation = $dataflow->validate_dataflow();
 
+        echo \html_writer::start_div('tool_dataflow-top-bar');
+
+        echo \html_writer::start_div('tool_dataflow-actions-bar');
         // Display the run now button (disabling it if dataflow is not valid).
         if ($validation === true) {
             $buttoncolour = 'btn-success';
@@ -272,6 +275,44 @@ class visualiser {
         $deletebutton->class .= ' ml-2';
         $content = $output->render($deletebutton);
         echo str_replace($btnuid, $icon . get_string('delete'), $content);
+        echo \html_writer::end_div(); // Closing tag for the .tool_dataflow-actions-bar div.
+
+        echo \html_writer::start_div('tool_dataflow-runs-bar');
+        // Display the most recent runs across the top, if it goes over a
+        // certain amount then it will link to a paginated table listing out the
+        // previous runs. This can have a background color to indicate the
+        // status of the run and only display the run name, etc.
+        // TODO: for now link to the "All runs" (for this dataflow) page containing the table.
+
+        $maxrunstoshow = 10;
+        $runs = $dataflow->get_runs($maxrunstoshow);
+
+        // Show this when the number of runs equals the max runs, and the first run in the list is NOT run #1.
+        if (count($runs) === $maxrunstoshow && ((int) reset($runs)->name !== 1)) {
+            $allrunsurl = new \moodle_url('/admin/tool/dataflows/runs.php', ['id' => $dataflow->id]);
+            $allruns = \html_writer::tag('button', get_string('all_runs', 'tool_dataflows'), ['class' => 'btn btn-run-default']);
+            echo \html_writer::link($allrunsurl, $allruns);
+        }
+
+        // Show up to the last 10 runs.
+        foreach ($runs as $run) {
+            $runurl = new \moodle_url('/admin/tool/dataflows/view-run.php', ['id' => $run->id]);
+            $runlabel = \html_writer::tag('button', $run->name, ['class' => 'btn btn-run-default']);
+            echo \html_writer::link($runurl, $runlabel);
+        }
+
+        // Recent runs label (no recent, or recent runs to describe the list).
+        if (!empty($runs)) {
+            $recentrunsstr = get_string('recent_runs', 'tool_dataflows');
+        } else {
+            $recentrunsstr = get_string('no_recent_runs', 'tool_dataflows');
+        }
+        $recentrunslabel = \html_writer::tag('span', $recentrunsstr, ['class' => 'btn btn-text']);
+        echo $recentrunslabel;
+
+        echo \html_writer::end_div(); // Closing tag for the .tool_dataflow-runs-bar div.
+
+        echo \html_writer::end_div(); // Closing tag for the .tool_dataflow-top-bar div.
 
         // Generate the image based on the DOT script.
         $contents = self::generate($dataflow->get_dotscript(), 'svg');

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -291,8 +291,7 @@ class visualiser {
         // Show this when the number of runs equals the max runs, and the first run in the list is NOT run #1.
         if (count($runs) === $maxrunstoshow && ((int) reset($runs)->name !== 1)) {
             $allrunsurl = new \moodle_url('/admin/tool/dataflows/runs.php', ['id' => $dataflow->id]);
-            $allruns = \html_writer::tag('button', get_string('all_runs', 'tool_dataflows'), ['class' => 'btn btn-run-default']);
-            echo \html_writer::link($allrunsurl, $allruns);
+            echo \html_writer::link($allrunsurl, get_string('all_runs', 'tool_dataflows'), ['class' => 'btn btn-run-default']);
         }
 
         // Show up to the last 10 runs.

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/dataflows/db" VERSION="20220624" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
+<XMLDB PATH="admin/tool/dataflows/db" VERSION="20220630" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -73,9 +73,9 @@
         <FIELD NAME="dataflowid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="This is the dataflow that this run is originally based on."/>
         <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="The user who started this particular run"/>
         <FIELD NAME="status" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="The current state of the run as a string, e.g. running, pausing, paused, finished, etc."/>
-        <FIELD NAME="timestarted" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false" COMMENT="Timestamp of when the run started"/>
-        <FIELD NAME="timepaused" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="timefinished" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="timestarted" TYPE="number" LENGTH="14" NOTNULL="false" SEQUENCE="false" DECIMALS="4" COMMENT="Timestamp of when the run started"/>
+        <FIELD NAME="timepaused" TYPE="number" LENGTH="14" NOTNULL="false" SEQUENCE="false" DECIMALS="4"/>
+        <FIELD NAME="timefinished" TYPE="number" LENGTH="14" NOTNULL="false" SEQUENCE="false" DECIMALS="4"/>
         <FIELD NAME="name" TYPE="char" LENGTH="11" NOTNULL="false" SEQUENCE="false" COMMENT="Identifier of the run, typically a single digit per unique run. A semver value, e.g. 1.1 if a run is re-executed using the same inputs"/>
         <FIELD NAME="startstate" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="currentstate" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="The current state of this run. This might be persisted after some time has elapsed since it started as a means of recovery, or if the user has paused the dataflow, such that it can be resumed at a later time."/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -33,5 +33,20 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
     global $DB;
     $dbman = $DB->get_manager();
 
+    if ($oldversion < 2022070501) {
+
+        // Changing type of field timestarted, timepaused, timefinished on table
+        // tool_dataflows_runs to number and precision to (14, 4).
+        $table = new xmldb_table('tool_dataflows_runs');
+
+        foreach (['timestarted', 'timepaused', 'timefinished'] as $fieldname) {
+            $field = new xmldb_field($fieldname, XMLDB_TYPE_NUMBER, '14, 4', null, null, null, null, null);
+            $dbman->change_field_type($table, $field);
+            $dbman->change_field_precision($table, $field);
+        }
+
+        // Dataflows savepoint reached.
+        upgrade_plugin_savepoint(true, 2022070501, 'tool', 'dataflows');
+    }
     return true;
 }

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -52,6 +52,9 @@ $string['dry_run'] = 'Dry run';
 $string['export'] = 'Export';
 $string['import'] = 'Import';
 $string['dataflow_enabled'] = 'Dataflow enabled';
+$string['all_runs'] = 'All runs';
+$string['recent_runs'] = 'Recent runs';
+$string['no_recent_runs'] = 'No recent runs';
 
 // Dataflows (form).
 $string['field_name'] = 'Name';
@@ -71,6 +74,17 @@ $string['remove_confirm'] = 'Are you sure you want to remove the step \'{$a}\'? 
 $string['remove_step_successful'] = 'Removed step \'{$a}\' successfully.';
 $string['remove_step'] = 'Remove step';
 $string['steps'] = 'Steps';
+
+// Dataflows runs (table).
+$string['run'] = 'Run';
+$string['runs'] = 'Runs';
+$string['field_status'] = 'Status';
+$string['field_timestarted'] = 'Started';
+$string['field_timefinished'] = 'Finished';
+$string['field_duration'] = 'Duration';
+$string['startstate'] = 'Start state';
+$string['currentstate'] = 'Current state';
+$string['endstate'] = 'End state';
 
 // Step names.
 $string['step_name_connector_curl'] = 'Curl connector';

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,7 @@
     display: flex;
     flex-direction: row-reverse;
     gap: 8px;
+    margin-bottom: 15px;
 }
 
 :where(.tool_dataflow-runs-bar, [id^="dataflow_runs_table"]) a.btn-run-default {

--- a/styles.css
+++ b/styles.css
@@ -22,3 +22,32 @@
     }
 }
 
+/* Dataflow Run buttons */
+.tool_dataflow-top-bar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+.tool_dataflow-runs-bar {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 8px;
+}
+
+:where(.tool_dataflow-runs-bar, [id^="dataflow_runs_table"]) .btn-run-default {
+    font-family: monospace;
+    background-color: #e9e7e7 !important;
+    color: black !important;
+    border-radius: 0 !important;
+}
+
+
+/* Dataflow 'run' table */
+.table-run td {
+    padding: 4px 6px;
+}
+
+tr:where(.field_timestarted, .field_timefinished) {
+    text-align: right;
+}
+

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,17 @@
+/* Dataflow engine states */
+:root {
+    --dataflow-state-new: #e9e7e7;
+    --dataflow-state-initialised: #e9e7e7;
+    --dataflow-state-blocked: #f07676;
+    --dataflow-state-waiting: #e9e7e7;
+    --dataflow-state-processing: yellow;
+    --dataflow-state-flowing: yellow; /* Background animates, text stays black */
+    --dataflow-state-finished: #17DB6D;
+    --dataflow-state-cancelled: #6D6969; /* Font color dims - background is 'new' */
+    --dataflow-state-aborted: #f07676;
+    --dataflow-state-finalised: #17DB6D;
+}
+
 .dataflow_invalid_step polygon {
     animation: dataflow_invalid_step 1s ease-out infinite alternate;
 }
@@ -28,17 +42,20 @@
     flex-wrap: wrap;
     justify-content: space-between;
 }
+.tool_dataflow-actions-bar {
+    margin-bottom: 15px;
+}
 .tool_dataflow-runs-bar {
     display: flex;
     flex-direction: row-reverse;
     gap: 8px;
 }
 
-:where(.tool_dataflow-runs-bar, [id^="dataflow_runs_table"]) .btn-run-default {
+:where(.tool_dataflow-runs-bar, [id^="dataflow_runs_table"]) a.btn-run-default {
     font-family: monospace;
-    background-color: #e9e7e7 !important;
-    color: black !important;
-    border-radius: 0 !important;
+    background-color: var(--dataflow-state-new);
+    color: black;
+    border-radius: 0;
 }
 
 
@@ -49,5 +66,40 @@
 
 tr:where(.field_timestarted, .field_timefinished) {
     text-align: right;
+}
+
+/* Dataflow run button color based on states */
+.btn-run-default.run-state-new { background-color: var(--dataflow-state-new); }
+.btn-run-default.run-state-initialised { background-color: var(--dataflow-state-initialised); }
+.btn-run-default.run-state-blocked { background-color: var(--dataflow-state-blocked); }
+.btn-run-default.run-state-waiting { background-color: var(--dataflow-state-waiting); }
+.btn-run-default.run-state-processing { background-color: var(--dataflow-state-processing); }
+.btn-run-default.run-state-flowing { background-color: var(--dataflow-state-flowing); }
+.btn-run-default.run-state-finished { background-color: var(--dataflow-state-finished); }
+.btn-run-default.run-state-cancelled { color: var(--dataflow-state-cancelled); background-color: var(--dataflow-state-new); }
+.btn-run-default.run-state-aborted { background-color: var(--dataflow-state-aborted); }
+.btn-run-default.run-state-finalised { background-color: var(--dataflow-state-finalised); }
+
+/* Group of run statuses considered to be 'running' */
+/* Animation adapted from concourse-ci */
+:where(.btn-run-default.run-state-processing, .btn-run-default.run-state-flowing) {
+    --color-stripe-1: rgb(247, 216, 89);
+    --color-stripe-2: rgb(242, 198, 21);
+    position: relative;
+    background-image: repeating-linear-gradient(
+        -115deg,
+        var(--color-stripe-1) 0px,
+        var(--color-stripe-2) 1px,
+        var(--color-stripe-2) 10px,
+        var(--color-stripe-1) 11px,
+        var(--color-stripe-1) 16px
+    );
+    background-size: 106px 114px;
+    animation: 3s linear 0s infinite normal none running dataflow-running;
+}
+
+@keyframes dataflow-running {
+    0% { background-position-x: -53.5px; }
+    100% { background-position-x: 0; }
 }
 

--- a/templates/run.mustache
+++ b/templates/run.mustache
@@ -1,0 +1,89 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template tool_dataflows/run
+
+    Displays the summary of the run
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * run persistent model
+
+    Example context (json):
+    {
+        "run": {
+            "name": "1.4",
+            "timestarted": "5 May 2022 11:33:01 AM",
+            "timefinished": "5 May 2022 11:33:02 AM",
+            "duration": "1 second",
+            ...
+        }
+    }
+}}
+<div class="accordion" id="dataflowRunStates">
+    <!-- Current State -->
+    {{^hasendstate}}
+    <div class="card">
+        <div class="card-header" id="currentstate">
+            <h2 class="mb-0">
+                <button class="btn btn-link btn-block text-left collapsed" type="button" data-toggle="collapse" data-target="#collapse-currentstate" aria-expanded="false" aria-controls="collapse-currentstate">
+                    {{#str}} currentstate, tool_dataflows {{/str}}
+                </button>
+            </h2>
+        </div>
+        <div id="collapse-currentstate" class="collapse show" aria-labelledby="currentstate" data-parent="#dataflowRunStates">
+            <pre class="card-body">{{currentstate}}</pre>
+        </div>
+    </div>
+    {{/hasendstate}}
+
+    <!-- Final state / End state -->
+    {{#hasendstate}}
+    <div class="card">
+        <div class="card-header" id="endstate">
+            <h2 class="mb-0">
+                <button class="btn btn-link btn-block text-left collapsed" type="button" data-toggle="collapse" data-target="#collapse-endstate" aria-expanded="false" aria-controls="collapse-endstate">
+                    {{#str}} endstate, tool_dataflows {{/str}}
+                </button>
+            </h2>
+        </div>
+        <div id="collapse-endstate" class="collapse show" aria-labelledby="endstate" data-parent="#dataflowRunStates">
+            <pre class="card-body">{{endstate}}</pre>
+        </div>
+    </div>
+    {{/hasendstate}}
+
+    <!-- Starting state -->
+    <div class="card">
+        <div class="card-header" id="startstate">
+            <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapse-startstate" aria-expanded="true" aria-controls="collapse-startstate">
+                {{#str}} startstate, tool_dataflows {{/str}}
+            </button>
+        </div>
+
+        <div id="collapse-startstate" class="collapse" aria-labelledby="startstate" data-parent="#dataflowRunStates">
+            <pre class="card-body">{{startstate}}</pre>
+        </div>
+    </div>
+</div>
+
+<!-- TODO: Add run logs underneath -->

--- a/tests/tool_dataflows_scheduler_test.php
+++ b/tests/tool_dataflows_scheduler_test.php
@@ -27,6 +27,7 @@ use tool_dataflows\local\scheduler;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_scheduler_test extends \advanced_testcase {
+
     /**
      * Set up before each test
      */

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022070500;
-$plugin->release = 2022070500;
+$plugin->version = 2022070501;
+$plugin->release = 2022070501;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
Added UI for dataflow runs, fixing some issues with data stored and added some (more) color to the new pages.

Testing colors for now, each run represents a different state. Can be tweaked later.

Dataflow details page:
![image](https://user-images.githubusercontent.com/9924643/175885115-d83d9cc3-d3fa-4c01-af70-e50e41394c5f.png)

Color Palette:
![image](https://user-images.githubusercontent.com/9924643/176601950-c0788d53-5bf5-42b6-b5b0-0cac72bcb076.png)

Runs view page:
![image](https://user-images.githubusercontent.com/9924643/176603190-3219e7c4-ba4d-43a4-a636-824d3e011b70.png)

All runs page:

![image](https://user-images.githubusercontent.com/9924643/176590066-62307adf-0dd7-414e-bae4-8b79ed83164b.png)


NTS: 
- [x] fix page breadcrumbs
- [x] fix data fill issues with start / finish states
- [x] fix all runs default display (css rules,prioritisation), should be more like:
![image](https://user-images.githubusercontent.com/9924643/175885852-7e3d6634-f6a7-4d5c-8f0b-8814d99e9a01.png)


Resolves #170 