### PR TITLE
fix: clarify output for one class of expression parsing errors

### DIFF
--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -109,11 +109,13 @@ class reader_sql extends reader_step {
                     $match['expressionwrapper'],
                     $variables,
                     function ($message, $e = null) use ($rawsql, &$errormsg) {
+                        // Process the message and clarify it if required.
+                        $message = $this->clarify_parser_error($message, $rawsql);
                         if (isset($e)) {
                             $errormsg = $message;
                             throw $e;
                         } else {
-                            $this->enginestep->log($message . " in the following query:\n{$rawsql}");
+                            $this->enginestep->log($message);
                         }
                     }
                 );
@@ -141,11 +143,9 @@ class reader_sql extends reader_step {
                 );
             }
         } catch (\Throwable $e) {
-            $message = "in query:\n{$rawsql}";
             if (!empty($errormsg)) {
-                $message = "$errormsg $message";
+                $this->enginestep->log($errormsg);
             }
-            $this->enginestep->log($message);
             throw $e;
         }
 
@@ -155,39 +155,8 @@ class reader_sql extends reader_step {
         $max = 5;
         while ($hasexpression && $max) {
             $finalsql = $parser->evaluate_or_fail($finalsql, $variables, function ($message, $e) {
-                // Check and massage the message if required.
-                $matches = null;
-                preg_match_all(
-                    // phpcs:disable moodle.Strings.ForbiddenStrings.Found
-                    '/Variable "(?<expressionpath>.*)" is not valid.*`(?<expression>.*)`.*for expression (?<sql>.*)/ms',
-                    $message,
-                    $matches,
-                    PREG_SET_ORDER);
-
-                if (!empty($matches)) {
-                    // Modify the SQL, adding a pointer to the first instance of the usage which resulted in the error.
-                    $match = (object) reset($matches);
-                    // Pinpoint the line and column of the expression in the SQL.
-                    $line = 0;
-                    $column = 0;
-                    $sqlbylines = explode("\n", $match->sql);
-                    foreach ($sqlbylines as $lineindex => $linecontents) {
-                        $position = strpos($linecontents, $match->expression);
-                        if ($position !== false) {
-                            $column = $position + 1;
-                            $line = $lineindex + 1;
-                            break;
-                        }
-                    }
-                    // Insert the characters in the following line.
-                    $sqlwithannotations = $this->draw_arrow_to_string_position($match->sql, $column, $line);
-                    $a = (object) array_merge((array) $match, [
-                        'sql' => $sqlwithannotations,
-                        'column' => $column,
-                        'line' => $line,
-                    ]);
-                    $message = get_string('reader_sql:variable_not_valid_in_position_replacement_text', 'tool_dataflows', $a);
-                }
+                // Process the message and clarify it if required.
+                $message = $this->clarify_parser_error($message);
 
                 // Log the message.
                 $this->enginestep->log($message);
@@ -203,6 +172,57 @@ class reader_sql extends reader_step {
     }
 
     /**
+     * Returns a clarified error message if applicable.
+     *
+     * @param   string $message
+     * @param   ?string $sql replacement for the expression held by default.
+     * @return  string clarified message if applicable
+     */
+    private function clarify_parser_error(string $message, ?string $sql = null): string {
+        // Check and massage the message if required.
+        $matches = null;
+        preg_match_all(
+            // phpcs:disable moodle.Strings.ForbiddenStrings.Found
+            '/Variable "(?<expressionpath>.*)" is not valid.*`(?<expression>.*)`.*for expression (?<sql>.*)/ms',
+            $message,
+            $matches,
+            PREG_SET_ORDER);
+
+        if (!empty($matches)) {
+            // Modify the SQL, adding a pointer to the first instance of the usage which resulted in the error.
+            $match = (object) reset($matches);
+
+            // Replace the field (using the sql key) in the matching expression with the one provided.
+            if (isset($sql)) {
+                $match->sql = $sql;
+            }
+
+            // Pinpoint the line and column of the expression in the SQL.
+            $line = 0;
+            $column = 0;
+            $sqlbylines = explode("\n", $match->sql);
+            foreach ($sqlbylines as $lineindex => $linecontents) {
+                $position = strpos($linecontents, $match->expression);
+                if ($position !== false) {
+                    $column = $position + 1;
+                    $line = $lineindex + 1;
+                    break;
+                }
+            }
+            // Insert the characters in the following line.
+            $sqlwithannotations = $this->draw_arrow_to_string_position($match->sql, $column, $line);
+            $a = (object) array_merge((array) $match, [
+                'sql' => $sqlwithannotations,
+                'column' => $column,
+                'line' => $line,
+            ]);
+            $message = get_string('reader_sql:variable_not_valid_in_position_replacement_text', 'tool_dataflows', $a);
+        }
+
+        return $message;
+    }
+
+    /**
      * Draws an arrow pointing at the focused position in a string
      *                                ^
      * @param   string $string of the original contents
@@ -210,7 +230,7 @@ class reader_sql extends reader_step {
      * @param   int $line line position to focus on
      * @return  string with arrow annotation
      */
-    private function draw_arrow_to_string_position($string, $column, $line) {
+    private function draw_arrow_to_string_position(string $string, int $column, int $line) {
         // Split by lines to ensure we insert it at the appropriate line.
         $sqlbylines = explode("\n", $string);
 

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -220,6 +220,7 @@ $string['reader_sql:counterfield'] = 'Counter field';
 $string['reader_sql:counterfield_help'] = 'Field in which the counter value is derived from. For example, the user <code>id</code> field in user related query';
 $string['reader_sql:countervalue'] = 'Counter Value';
 $string['reader_sql:countervalue_help'] = 'Current value from the counter field';
+$string['reader_sql:variable_not_valid_in_position_replacement_text'] = "Invalid expression \${{ {\$a->expression} }} as `{\$a->expressionpath}` could not be resolved at line {\$a->line} character {\$a->column} in:\n{\$a->sql}"; // phpcs:disable moodle.Strings.ForbiddenStrings.Found
 
 // Cron trigger.
 $string['trigger_cron:cron'] = 'Scheduled task';


### PR DESCRIPTION
This is when the variable used in the expression, could not be resolved. This is likely because the variables array provided during evaluation did not exist as a property/key.

Full output looks like the following (given this workflow: [Delta_export_of_users_20220701_0542.yml.txt](https://github.com/catalyst/moodle-tool_dataflows/files/9025686/Delta_export_of_users_20220701_0542.yml.txt)):
```
2022 Jul  1, 15:41:59.650 Engine "Delta export of users": status: new 
2022 Jul  1, 15:41:59.660 Engine "Delta export of users", step "SQL reader": status: new 
2022 Jul  1, 15:41:59.660 Engine "Delta export of users", step "write to csv": status: new 
2022 Jul  1, 15:41:59.661 Engine "Delta export of users", step "SQL reader": status: initialised 
2022 Jul  1, 15:41:59.661 Engine "Delta export of users", step "write to csv": status: initialised 
2022 Jul  1, 15:41:59.661 Engine "Delta export of users": status: initialised, config: {"isdryrun":false} 
2022 Jul  1, 15:41:59.681 Engine "Delta export of users": status: processing 
2022 Jul  1, 15:41:59.681 Engine "Delta export of users", step "write to csv": status: waiting 
2022 Jul  1, 15:41:59.717 Engine "Delta export of users", step "SQL reader": Invalid expression ${{ config.num }} as `config` could not be resolved at line 2 character 25 in:
SELECT generate_series AS num
FROM generate_series(${{config.num}}, ${{config.num}} + 3)
                        ^
 
2022 Jul  1, 15:41:59.717 Engine "Delta export of users", step "SQL reader": status: aborted 
2022 Jul  1, 15:41:59.717 Engine "Delta export of users": status: aborted 
2022 Jul  1, 15:41:59.717 Engine "Delta export of users": Aborted: Variable "config" is not valid around position 1 for expression `config.num`. 
2022 Jul  1, 15:41:59.718 Engine "Delta export of users": Symfony\Component\ExpressionLanguage\SyntaxError: Variable "config" is not valid around position 1 for expression `config.num`. in /var/www/moodle/admin/tool/dataflows/vendor/symfony/expression-language/Parser.php:204
Stack trace:
#0 /var/www/moodle/admin/tool/dataflows/vendor/symfony/expression-language/Parser.php(149): Symfony\Component\ExpressionLanguage\Parser->parsePrimaryExpression()
#1 /var/www/moodle/admin/tool/dataflows/vendor/symfony/expression-language/Parser.php(110): Symfony\Component\ExpressionLanguage\Parser->getPrimary()
#2 /var/www/moodle/admin/tool/dataflows/vendor/symfony/expression-language/Parser.php(100): Symfony\Component\ExpressionLanguage\Parser->parseExpression()
#3 /var/www/moodle/admin/tool/dataflows/vendor/symfony/expression-language/ExpressionLanguage.php(105): Symfony\Component\ExpressionLanguage\Parser->parse(Object(Symfony\Component\ExpressionLanguage\TokenStream), Array)
#4 /var/www/moodle/admin/tool/dataflows/vendor/symfony/expression-language/ExpressionLanguage.php(78): Symfony\Component\ExpressionLanguage\ExpressionLanguage->parse('config.num', Array)
#5 /var/www/moodle/admin/tool/dataflows/classes/parser.php(94): Symfony\Component\ExpressionLanguage\ExpressionLanguage->evaluate('config.num', Array)
#6 /var/www/moodle/admin/tool/dataflows/classes/parser.php(59): tool_dataflows\parser->internal_evaluator('SELECT generate...', Array, Object(Closure))
#7 /var/www/moodle/admin/tool/dataflows/classes/local/step/reader_sql.php(197): tool_dataflows\parser->evaluate_or_fail('SELECT generate...', Array, Object(Closure))
#8 /var/www/moodle/admin/tool/dataflows/classes/local/step/reader_sql.php(54): tool_dataflows\local\step\reader_sql->construct_query()
#9 /var/www/moodle/admin/tool/dataflows/classes/local/execution/flow_engine_step.php(59): tool_dataflows\local\step\reader_sql->get_iterator(Object(tool_dataflows\local\execution\flow_engine_step))
#10 /var/www/moodle/admin/tool/dataflows/classes/local/execution/engine.php(250): tool_dataflows\local\execution\flow_engine_step->go()
#11 /var/www/moodle/admin/tool/dataflows/classes/local/execution/engine.php(217): tool_dataflows\local\execution\engine->execute_step()
#12 /var/www/moodle/admin/tool/dataflows/run.php(109): tool_dataflows\local\execution\engine->execute()
#13 {main} 
```

Compared with the one linked in the original issue.

I've opted to keep, and pass along the original exception for an accurate trace.

This is the cut down output of one where an optional query fragment is used:
```
2022 Jul  1, 16:02:56.961 Engine "Delta export of users", step "write to csv": status: waiting 
2022 Jul  1, 16:02:57.024 Engine "Delta export of users", step "SQL reader": Invalid expression ${{ config.num }} as `config` could not be resolved at line 2 character 15 in:
SELECT generate_series AS num
[[ , 1 as ${{ config.num }} ]]
              ^
FROM generate_series(${{config.num}}, ${{config.num}} + 3)
 
2022 Jul  1, 16:02:57.024 Engine "Delta export of users", step "SQL reader": status: aborted 
```

Resolves #206
