### PR TITLE
feat: show a list of available, known fields usable in expressions

### DIFF
--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -108,6 +108,8 @@ $string['stepgroupflows'] = 'Flows';
 $string['stepgroupreaders'] = 'Reader steps';
 
 // Step (form).
+$string['available_fields'] = 'Available Fields';
+$string['available_fields_help'] = 'The fields listed below can be referenced in any step configuration, e.g. {$a}';
 $string['field_description'] = 'Description';
 $string['field_alias'] = 'Alias';
 $string['field_alias_help'] = 'A snake cased reference to the step, unique to this dataflow. This can be used when referencing dependencies and inputs from other steps. Leaving this field blank will attempt to use a snake case version of the name value. For example, if the name is "My Step", it will be populate this field as "my_step"';

--- a/templates/available-fields.mustache
+++ b/templates/available-fields.mustache
@@ -1,0 +1,51 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template tool_dataflows/available-fields
+
+    Displays form element containg all available fields.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * none
+
+    Example context (json):
+    {
+    }
+
+}}
+<div class="form-group row">
+    <div class="col-md-3">
+        <p>{{# str }} available_fields, tool_dataflows {{/ str }}</p>
+    </div>
+    <div class="fieldcontainer col-md-9 form-inline felement">
+        <p>{{# str }} available_fields_help, tool_dataflows, <code>${<span></span>{ dataflow.name }}</code> {{/ str }}</p>
+        {{#groups}}
+            <div class="fieldtitle text-capitalize">{{ name }}:</div>
+            <div class="fieldgroup">
+                {{#fields}}
+                    <span class="badge badge-dark rounded-0 mb-1 mr-1" title="{{ title }}">{{ text }}</span>
+                {{/fields}}
+            </div>
+        {{/groups}}
+    </div>
+</div>

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022070501;
-$plugin->release = 2022070501;
+$plugin->version = 2022070502;
+$plugin->release = 2022070502;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
Here's a preview:

![image](https://user-images.githubusercontent.com/9924643/177104297-3be17ddb-9c06-4a48-b076-ae95c3840df2.png)

Note that it doesn't have run-time variables available, in particular, it doesn't list flow variables within the same scope as the flow, but that's okay, it's still reference-able currently.

TIP: that you should also see the value (if set) of the corresponding key when hovering over the particular entry (e.g. with the mouse over the curl url)

![image](https://user-images.githubusercontent.com/9924643/177236423-7f5ca5e2-8173-4ee4-b276-fd041d4b64a8.png)

Resolves #199 

