### PR TITLE
style: fix remaining trailing comma phpcs issues

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -209,7 +209,7 @@ class dataflow extends persistent {
                 'DATAFLOW_RUN_NAME' => $this->engine->run->name ?? null,
             ],
             'dataflow' => $dataflow,
-            'steps' => $steps
+            'steps' => $steps,
         ];
         return $variables;
     }

--- a/classes/local/step/connector_s3.php
+++ b/classes/local/step/connector_s3.php
@@ -92,7 +92,7 @@ class connector_s3 extends connector_step {
         $config = $this->enginestep->stepdef->config;
         $connectionoptions = [
             'version' => 'latest',
-            'region' => $config->region
+            'region' => $config->region,
         ];
         if ($config->key !== '') {
             $connectionoptions['credentials'] = [

--- a/classes/step.php
+++ b/classes/step.php
@@ -547,11 +547,12 @@ class step extends persistent {
         $steptype = $this->steptype;
         [$min, $max] = $steptype->$fn();
         if ($count < $min || $count > $max) {
-            return ["invalid_count_{$inputoutput}{$flowconnector}s_{$this->id}" => get_string(
-                "stepinvalid{$inputoutput}{$flowconnector}count",
-                'tool_dataflows',
-                $count
-            ) . ' ' . visualiser::get_link_expectations($steptype, $inputoutput)
+            return [
+                "invalid_count_{$inputoutput}{$flowconnector}s_{$this->id}" => get_string(
+                    "stepinvalid{$inputoutput}{$flowconnector}count",
+                    'tool_dataflows',
+                    $count
+                ) . ' ' . visualiser::get_link_expectations($steptype, $inputoutput),
             ];
         }
         return true;

--- a/edit.php
+++ b/edit.php
@@ -56,7 +56,7 @@ if (!empty($id)) {
 // Render the specific dataflow form.
 $customdata = [
     'persistent' => $persistent ?? null, // An instance, or null.
-    'userid' => $USER->id // For the hidden userid field.
+    'userid' => $USER->id, // For the hidden userid field.
 ];
 $form = new dataflow_form($PAGE->url->out(false), $customdata);
 if ($form->is_cancelled()) {

--- a/tests/tool_dataflows_secret_service_test.php
+++ b/tests/tool_dataflows_secret_service_test.php
@@ -56,7 +56,7 @@ class tiny_connector_s3 extends connector_s3 {
             'secret'            => ['type' => PARAM_TEXT, 'secret' => true],
             'source'            => ['type' => PARAM_TEXT],
             'target'            => ['type' => PARAM_TEXT],
-            'sourceremote'      => ['type' => PARAM_BOOL]
+            'sourceremote'      => ['type' => PARAM_BOOL],
         ];
     }
 }


### PR DESCRIPTION
There's a bug in phpcs that is preventing these checks from catching all cases. With this in mind, I've opted to use the Drupal standards to catch these missing cases which seems to work well. The rule is "Drupal.Arrays.Array.CommaLastItem"

Adds on to the PR which resolved #277

I've installed the standards as follows for those wondering:
```
# Install the drupal standard as a composer package (global)
composer global require drupal/coder
# Change to the standards dir:
cd /usr/share/php/PHP/CodeSniffer/src/Standards/
# Symlink them their proper standards name (I did it this way, might not be the 'best' way)
sudo ln -sf /home/currentuser/.config/composer/vendor/drupal/coder/coder_sniffer/Drupal Drupal
sudo ln -sf /home/currentuser/.config/composer/vendor/slevomat/coding-standard/SlevomatCodingStandard SlevomatCodingStandard

```