### PR TITLE
fix: step through fixing issues shown in the UI for an invalid step type

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -322,7 +322,7 @@ class dataflow extends persistent {
 
         // Check if each step is valid based on its own definition of valid (e.g. which could be based on configuration).
         foreach ($steps as $step) {
-            if ($step->steptype->get_group() == 'triggers') {
+            if (isset($step->steptype) && $step->steptype->get_group() == 'triggers') {
                 ++$numtriggers;
             }
             $stepvalidation = $step->validate_step();

--- a/classes/dataflows_table.php
+++ b/classes/dataflows_table.php
@@ -129,6 +129,10 @@ class dataflows_table extends \table_sql {
         $dataflow = new dataflow($record->id);
         foreach ($dataflow->steps as $step) {
             $steptype = $step->steptype;
+            if (!isset($steptype)) {
+                continue;
+            }
+
             $extrainfo = $steptype->get_details();
             if (!empty($extrainfo)) {
                 $content[] = $extrainfo;

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -123,8 +123,10 @@ class step_form extends \core\form\persistent {
 
         // Check and set custom form inputs if required. Defaulting to a
         // textarea config input for those not yet configured.
-        $steptype = $persistent->steptype ?? new $type();
-        $steptype->form_setup($mform);
+        if (isset($persistent->steptype) || (isset($type) && class_exists($type))) {
+            $steptype = $persistent->steptype ?? new $type();
+            $steptype->form_setup($mform);
+        }
         $this->add_action_buttons();
     }
 

--- a/classes/step.php
+++ b/classes/step.php
@@ -147,7 +147,7 @@ class step extends persistent {
      */
     public function get_steptype() {
         $classname = $this->type;
-        if (!empty($classname)) {
+        if (!empty($classname) && class_exists($classname)) {
             return new $classname($this);
         } else {
             return null;
@@ -185,7 +185,7 @@ class step extends persistent {
         }
 
         // Ensure the secret service gets involved to redact any information required.
-        if ($redacted) {
+        if ($redacted && isset($this->type)) {
             $secretservice = new secret_service;
             $steptype = new $this->type;
             $yaml = $secretservice->redact_fields($yaml, $steptype->get_secret_fields());
@@ -575,6 +575,11 @@ class step extends persistent {
         if ($count != 0) {
             $dep = array_shift($deps);
             $classname = $dep->type;
+            // By default, if a step type doesn't exist, then it's flows cannot
+            // be validated so default to true.
+            if (!class_exists($classname)) {
+                return true;
+            }
             $type = new $classname();
             $isflow = $type->is_flow();
 

--- a/classes/steps_table.php
+++ b/classes/steps_table.php
@@ -181,6 +181,9 @@ class steps_table extends \table_sql {
     public function col_details(\stdClass $record): string {
         $step = new step($record->id);
         $steptype = $step->steptype;
+        if (!isset($steptype)) {
+            return '';
+        }
         return $steptype->get_details();
     }
 

--- a/step.php
+++ b/step.php
@@ -170,7 +170,11 @@ echo $OUTPUT->heading($heading);
 $output = $PAGE->get_renderer('tool_dataflows');
 
 // Step summary including existing links and link requirements.
-$steptype = new $type();
+$typename = $type;
+if (class_exists($type)) {
+    $steptype = new $type();
+    $typename = $steptype->get_name();
+}
 if (is_null($persistent)) {
     $persistent = new step();
     $persistent->name = get_string('new_step', 'tool_dataflows');
@@ -186,10 +190,13 @@ $data = [
                 return ['href' => new moodle_url('/admin/tool/dataflows/step.php', ['id' => $v->id]), 'label' => $v->name];
             }, $persistent->dependents())),
     'dotimage' => visualiser::generate($persistent->get_dotscript(), 'svg'),
-    'typename' => $steptype->get_name(),
-    'inputrequirements' => visualiser::get_link_expectations($steptype, 'input'),
-    'outputrequirements' => visualiser::get_link_expectations($steptype, 'output'),
+    'typename' => $typename,
 ];
+
+if (isset($steptype)) {
+    $data['inputrequirements'] = visualiser::get_link_expectations($steptype, 'input');
+    $data['outputrequirements'] = visualiser::get_link_expectations($steptype, 'output');
+}
 
 echo $output->render_from_template('tool_dataflows/step-summary', $data);
 


### PR DESCRIPTION
Resolves #273 

Manage flows page loads, and going into the dataflow and step no longer stops with an exception. The user can still navigate around as intended.

![image](https://user-images.githubusercontent.com/9924643/178209030-ed07b7be-3f2c-46c6-9469-4d1b12f1a5ba.png)

![image](https://user-images.githubusercontent.com/9924643/178209131-4e88f150-9028-4755-8195-0f065fd59155.png)
