### PR TITLE
264 add sort order to json reader

### DIFF
--- a/classes/local/step/reader_json.php
+++ b/classes/local/step/reader_json.php
@@ -190,6 +190,6 @@ class reader_json extends reader_step {
         $mform->addElement('text', 'config_arraysortexpression', get_string('reader_json:arraysortexpression', 'tool_dataflows'));
         $mform->addElement('static', 'config_arraysortexpression_help', '',
             get_string('reader_json:arraysortexpression_help', 'tool_dataflows',
-                html_writer::nonempty_tag('code', 'usersdetails.firstname')));
+                html_writer::nonempty_tag('code', 'userdetails.firstname')));
     }
 }

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -252,12 +252,14 @@ $string['reader_sql:countervalue_help'] = 'Current value from the counter field'
 $string['reader_sql:variable_not_valid_in_position_replacement_text'] = "Invalid expression \${{ {\$a->expression} }} as `{\$a->expressionpath}` could not be resolved at line {\$a->line} character {\$a->column} in:\n{\$a->sql}"; // phpcs:disable moodle.Strings.ForbiddenStrings.Found
 
 // Reader JSON.
-$string['reader_json:arrayexpression'] = 'Array Expression';
 $string['reader_json:arrayexpression_help'] = 'Nested array to extract from JSON. For example, {$a->expression} will return the users array from the following JSON (If empty it is assumed the starting point of the JSON file is an array):{$a->jsonexample}';
-$string['reader_json:arraysortexpression'] = 'Sort by';
+$string['reader_json:arrayexpression'] = 'Array Expression';
 $string['reader_json:arraysortexpression_help'] = 'Value to sort array by, this value needs to be present in the return array. For the example above, setting this value to {$a} will return an array sorted by the firstname value in the users array.';
-$string['reader_json:pathtojson'] = 'Path to JSON Array';
+$string['reader_json:arraysortexpression'] = 'Sort by';
 $string['reader_json:json_path_help'] = 'For example, setting {$a} will parse the JSON file at the location.';
+$string['reader_json:pathtojson'] = 'Path to JSON Array';
+$string['reader_json:sortorder'] = 'Sort Order';
+$string['reader_json:sortorder_help'] = 'This will apply if the \'Sort by\' has been set. Otherwise the records will remain untouched in their original order.';
 
 // Cron trigger.
 $string['trigger_cron:cron'] = 'Scheduled task';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022071102;
-$plugin->release = 2022071102;
+$plugin->version = 2022071300;
+$plugin->release = 2022071300;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
- fix: example key usersdetails corrected to userdetails
- feat: add sort order to the json reader step

![image](https://user-images.githubusercontent.com/9924643/178636508-dd3af64d-7c94-40f2-bd3f-cb22ae3235eb.png)

Resolves #264 