### PR TITLE
fix: restrict generation of the dot graph to when site has set pathtodot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,6 @@ jobs:
     with:
       disable_behat: true
       disable_grunt: true
-      extra_plugin_runners: 'moodle-plugin-ci add-plugin catalyst/moodle-local_aws --branch ci-for-tool_dataflows'
+      extra_plugin_runners: |
+          moodle-plugin-ci add-plugin catalyst/moodle-local_aws --branch ci-for-tool_dataflows;
+          sudo apt-get install -y graphviz;


### PR DESCRIPTION
Initially added a way to skip dot graph generation if the path is not set, but there wasn't a quick way to include the necessary config values, which would have resulted in a fixed added option in reusable workflows which isn't great. 

For now, adding the dot CLI will cause the unit tests to fail successfully

Resolves #290 