### PR TITLE
chore: CI will now fail on codechecker warnings/errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       # Required if you plan to publish (uncomment the below)
       # moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
     with:
+      codechecker_max_warnings: 0 # CI should now fail on phpcs / code checker warnings.
       disable_behat: true
       disable_grunt: true
       extra_plugin_runners: 'moodle-plugin-ci add-plugin catalyst/moodle-local_aws --branch ci-for-tool_dataflows'


### PR DESCRIPTION
This is to ensure a consistently clean codebase.

Resolves #292
