### PR TITLE
Issue #289: Fix failing unit tests.

### DIFF
--- a/classes/step.php
+++ b/classes/step.php
@@ -171,9 +171,10 @@ class step extends persistent {
      * expressions are evaluated at this point in time.
      *
      * @param   bool $expressions whether or not to parse expressions when returning the config
+     * @param   bool $redacted Will redact secret values if true
      * @return  \stdClass configuration object
      */
-    protected function get_config($expressions = true, $redacted = false): \stdClass {
+    protected function get_config($expressions = true, bool $redacted = false): \stdClass {
         $rawconfig = $this->raw_get('config');
         $yaml = $rawconfig;
         if (gettype($rawconfig) === 'string') {
@@ -184,10 +185,11 @@ class step extends persistent {
             return new \stdClass();
         }
 
+        $steptype = $this->get_steptype();
+
         // Ensure the secret service gets involved to redact any information required.
-        if ($redacted && isset($this->type)) {
+        if ($redacted && isset($steptype)) {
             $secretservice = new secret_service;
-            $steptype = new $this->type;
             $yaml = $secretservice->redact_fields($yaml, $steptype->get_secret_fields());
         }
 

--- a/tests/tool_dataflows_curl_connector_test.php
+++ b/tests/tool_dataflows_curl_connector_test.php
@@ -143,10 +143,12 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
         ob_get_clean();
         $variables = $engine->get_variables()['steps']->connector->config;
         $this->assertObjectNotHasAttribute('result', $variables);
-        $this->assertEquals($variables->dbgcommand, "curl -X POST {$testurl} -d '{
+        $expected = "curl -X POST {$testurl} -d '{
                 \"name\": \"morpheus\",
                 \"job\": \"leader\"
-            }'\n");
+            }'";
+        // Use trim here because it seems that some versions of Yaml put a EOL when dumping, and others don't.
+        $this->assertEquals($expected, trim($variables->dbgcommand));
 
         // Test file writting.
         $tofile = "test.html";

--- a/tests/tool_dataflows_secret_service_test.php
+++ b/tests/tool_dataflows_secret_service_test.php
@@ -209,7 +209,7 @@ class tool_dataflows_secret_service_test extends \advanced_testcase {
 
         // Capture table output.
         ob_start();
-        $table->out(0, false);
+        $table->out(1, false); // Pagesize needs to be 1 for compatibility with 3.5.
         $output = ob_get_clean();
         $regex = '/' . self::SECRET . '/';
 
@@ -217,7 +217,7 @@ class tool_dataflows_secret_service_test extends \advanced_testcase {
         // (which reassures the step data was indeed outputted).
         foreach ($steps as $step) {
             $this->compatible_assertStringContainsString($step->name, $output);
-            $this->compatible_assertStringContainsString($step->id, $output);
+            $this->compatible_assertStringContainsString("$step->id", $output);
             $this->compatible_assertStringContainsString($step->alias, $output);
         }
 


### PR DESCRIPTION
resolves #289 

Removed '\n' from expected value in curl_connector_test.
Swapped to values so the expected value is passed first.

Changed step::get_config() to get steptype from get_steptype. This fixed
weird error where isset($this->type) was returning false even though it has a value.