### PR TITLE
260 add more flexible vars

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -136,7 +136,16 @@ class dataflow extends persistent {
             $steps[$key]['alias'] = $key;
             $steps[$key]['states'] = $step->states;
             $steps[$key]['outputs'] = $step->outputs;
+
+            // For a 'better' experience, the output values will be referencable
+            // from the base step key itself, e.g. instead of
+            // steps.alias.outputs.somefield, it would just be
+            // steps.alias.somefield.
+            foreach ($step->outputs as $somefield => $somevalue) {
+                $steps[$key][$somefield] = $somevalue;
+            }
         }
+
         foreach ($steps as &$step) {
             foreach ($step as &$field) {
                 if (is_array($field)) {

--- a/classes/local/execution/connector_engine_step.php
+++ b/classes/local/execution/connector_engine_step.php
@@ -45,6 +45,7 @@ class connector_engine_step extends engine_step {
             case self::PROCEED_GO:
                 try {
                     $result = $this->steptype->execute($this);
+                    $this->steptype->prepare_outputs();
                     if ($result === true) {
                         $this->set_status(engine::STATUS_FINISHED);
                     } else {

--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -134,6 +134,10 @@ class dataflow_iterator implements iterator {
         // Processes it.
         $this->on_next();
         $newvalue = $this->steptype->execute($this->value);
+
+        // Handle step outputs - noting that for flow steps, the values may change between each iteration.
+        $this->steptype->prepare_outputs();
+
         ++$this->iterationcount;
         $this->step->log('Iteration ' . $this->iterationcount . ': ' . json_encode($newvalue));
 

--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -197,14 +197,19 @@ class connector_curl extends connector_step {
         }
 
         if (!$isdryrun) {
-            $this->enginestep->stepdef->set_var('result', $result);
-            $this->enginestep->stepdef->set_var('httpcode', $httpcode);
-            $this->enginestep->stepdef->set_var('connecttime', $connecttime);
-            $this->enginestep->stepdef->set_var('totaltime', $totaltime);
-            $this->enginestep->stepdef->set_var('sizeupload', $sizeupload);
-            $this->enginestep->stepdef->set_var('destination', $destination);
+            // TODO: It would be good to define and list any fixed but exposed
+            // fields which the user can use and map to on the edit page.
+            $this->set_variables('response', (object) [
+                'result' => $result,
+                'info' => $info,
+                'httpcode' => $httpcode,
+                'connecttime' => $connecttime,
+                'totaltime' => $totaltime,
+                'sizeupload' => $sizeupload,
+                'destination' => $destination,
+            ]);
         } else {
-            $this->enginestep->stepdef->set_var('dbgcommand', $dbgcommand);
+            $this->set_variables('dbgcommand', $dbgcommand);
         }
         return true;
     }

--- a/classes/parser.php
+++ b/classes/parser.php
@@ -62,7 +62,7 @@ class parser {
             }
 
             // If the field is a nested object, recurse and continue evalulating.
-            if (is_object($string)) {
+            if (is_object($string) || is_array($string)) {
                 $string = $this->evaluate_recursive($string, $variables);
                 continue;
             }
@@ -82,6 +82,9 @@ class parser {
                 if ($hasexpression) {
                     $resolved = $this->evaluate($string, $variables);
                     if ($resolved !== $string) {
+                        if (is_array($yaml)) {
+                            $yaml = (object) $yaml;
+                        }
                         $yaml->{$key} = $resolved;
                         $resolvedvalues->{$key} = $resolved;
                         $max++;

--- a/tests/tool_dataflows_curl_connector_test.php
+++ b/tests/tool_dataflows_curl_connector_test.php
@@ -63,6 +63,13 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
             'destination' => '',
             'headers' => '',
             'method' => 'get',
+            'outputs' => [
+                'result' => '${{ fromJSON(response.result) }}',
+                'httpcode' => '${{ response.httpcode }}',
+                'connecttime' => '${{ response.connecttime }}',
+                'totaltime' => '${{ response.totaltime }}',
+                'sizeupload' => '${{ response.sizeupload }}',
+            ],
         ]);
         $stepdef->name = 'connector';
         $stepdef->type = 'tool_dataflows\local\step\connector_curl';
@@ -71,10 +78,10 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
         $engine = new engine($dataflow, false, false);
         $engine->execute();
         ob_get_clean();
-        $variables = $engine->get_variables()['steps']->connector->config;
+        $variables = $engine->get_variables()['steps']->connector->outputs;
         // Result can be anything but for readability decoded to see vars.
-        $result = json_decode($variables->result, true);;
-        $this->assertEquals($result['uuid'], '3d188fbf-d0b7-4d4e-ae4d-4b5548df824e');
+        $result = $variables->result;
+        $this->assertEquals($result->uuid, '3d188fbf-d0b7-4d4e-ae4d-4b5548df824e');
 
         $this->assertEquals($variables->httpcode, 200);
         $this->assertObjectHasAttribute('connecttime', $variables);
@@ -90,13 +97,20 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
             'headers' => '',
             'method' => 'post',
             'rawpostdata' => 'data=moodletest',
+            'outputs' => [
+                'result' => '${{ response.result }}',
+                'httpcode' => '${{ response.httpcode }}',
+                'connecttime' => '${{ response.connecttime }}',
+                'totaltime' => '${{ response.totaltime }}',
+                'sizeupload' => '${{ response.sizeupload }}',
+            ],
         ]);
         $dataflow->add_step($stepdef);
         ob_start();
         $engine = new engine($dataflow, false, false);
         $engine->execute();
         ob_get_clean();
-        $variables = $engine->get_variables()['steps']->connector->config;
+        $variables = $engine->get_variables()['steps']->connector->outputs;
 
         $this->assertEmpty($variables->result);
         $this->assertEquals($variables->httpcode, 200);
@@ -111,13 +125,20 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
             'headers' => '',
             'method' => 'put',
             'rawpostdata' => 'data=moodletest',
+            'outputs' => [
+                'result' => '${{ response.result }}',
+                'httpcode' => '${{ response.httpcode }}',
+                'connecttime' => '${{ response.connecttime }}',
+                'totaltime' => '${{ response.totaltime }}',
+                'sizeupload' => '${{ response.sizeupload }}',
+            ],
         ]);
         $dataflow->add_step($stepdef);
         ob_start();
         $engine = new engine($dataflow, false, false);
         $engine->execute();
         ob_get_clean();
-        $variables = $engine->get_variables()['steps']->connector->config;
+        $variables = $engine->get_variables()['steps']->connector->outputs;
 
         $this->assertEmpty($variables->result);
         $this->assertEquals($variables->httpcode, 200);
@@ -135,14 +156,14 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
                 "name": "morpheus",
                 "job": "leader"
             }',
+            'outputs' => ['dbgcommand' => '${{ dbgcommand }}'],
         ]);
         $dataflow->add_step($stepdef);
         ob_start();
         $engine = new engine($dataflow, true, false);
         $engine->execute();
         ob_get_clean();
-        $variables = $engine->get_variables()['steps']->connector->config;
-        $this->assertObjectNotHasAttribute('result', $variables);
+        $variables = $engine->get_variables()['steps']->connector->outputs;
         $expected = "curl -X POST {$testurl} -d '{
                 \"name\": \"morpheus\",
                 \"job\": \"leader\"
@@ -157,13 +178,17 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
             'destination' => $tofile,
             'headers' => '',
             'method' => 'get',
+            'outputs' => [
+                'httpcode' => '${{ response.httpcode }}',
+                'destination' => '${{ response.destination }}',
+            ],
         ]);
         $dataflow->add_step($stepdef);
         ob_start();
         $engine = new engine($dataflow, false, false);
         $engine->execute();
         ob_get_clean();
-        $variables = $engine->get_variables()['steps']->connector->config;
+        $variables = $engine->get_variables()['steps']->connector->outputs;
         $destination = $variables->destination;
         $httpcode = $variables->httpcode;
         $this->assertFileExists($destination);
@@ -174,9 +199,9 @@ class tool_dataflows_curl_connector_test extends \advanced_testcase {
         // Checks that it can properly be referenced for future steps.
         $expressedvalue = $expressionlanguage->evaluate('steps.connector.config.curl', $variables);
         $this->assertEquals($testgeturl, $expressedvalue);
-        $expressedvalue = $expressionlanguage->evaluate('steps.connector.config.destination', $variables);
+        $expressedvalue = $expressionlanguage->evaluate('steps.connector.outputs.destination', $variables);
         $this->assertEquals($destination, $expressedvalue);
-        $expressedvalue = $expressionlanguage->evaluate('steps.connector.config.httpcode', $variables);
+        $expressedvalue = $expressionlanguage->evaluate('steps.connector.outputs.httpcode', $variables);
         $this->assertEquals($httpcode, $expressedvalue);
     }
 

--- a/tests/tool_dataflows_variables_test.php
+++ b/tests/tool_dataflows_variables_test.php
@@ -321,5 +321,8 @@ class tool_dataflows_variables_test extends \advanced_testcase {
         $variables = $engine->get_variables();
         $result = $expressionlanguage->evaluate("steps.{$stepdef->name}.outputs.customOutputKey", $variables);
         $this->assertEquals('H5P.Accordion', $result);
+        // Test the shorthand version also.
+        $result = $expressionlanguage->evaluate("steps.{$stepdef->name}.customOutputKey", $variables);
+        $this->assertEquals('H5P.Accordion', $result);
     }
 }


### PR DESCRIPTION
Resolves #260 

tl;dr:
- steps expose their variables
- you declare what you want from the step
- you can use that in steps that come after

What this doesn't do is modify the input as it flows through. The concern was with a step doing too many things, and if used in another step later on such as a json writer step, you don't necessarily want the input (json / php object flowing through) to be polluted with all these additional things you've picked up along the way.

I think there should be a some _transformer_ step which uses these output variables and will explicitly update the input as it flows through, when required.