### PR TITLE
304 add support for step dep ordering

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -546,7 +546,11 @@ class dataflow extends persistent {
             ]);
             if (isset($dependency->position)) {
                 $outputlabel = $srcstep->steptype->get_output_label($dependency->position);
-                $connectionstyles = ['label' => $outputlabel];
+                $connectionstyles = [
+                    'label' => $outputlabel,
+                    'fontsize'  => '10',
+                    'fontname'  => 'San Serif',
+                ];
             }
 
             // Final styles.

--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -284,7 +284,8 @@ class dataflow extends persistent {
                        sd.stepid AS dest
                   FROM {tool_dataflows_step_depends} sd
              LEFT JOIN {tool_dataflows_steps} step ON step.id = sd.stepid
-                 WHERE step.dataflowid = :dataflowid";
+                 WHERE step.dataflowid = :dataflowid
+              ORDER BY sd.position ASC";
 
         // Note that this works currently because all dependencies are set for each step.
         $edges = $DB->get_records_sql($sql, ['dataflowid' => $this->id]);

--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -496,6 +496,8 @@ class dataflow extends persistent {
      * @return     string dotscript
      */
     public function get_dotscript(): string {
+        global $DB;
+
         // Fetch the dot script node from each step to construct them.
         $steps = $this->steps;
         $nodes = [];
@@ -535,7 +537,20 @@ class dataflow extends persistent {
                     $localstyles['color'] = '#008196';
                 }
             }
-            $finalstyles = array_merge($baseconnectionstyles, $localstyles);
+
+            // Output connection labels, if applicable.
+            $connectionstyles = [];
+            $dependency = $DB->get_record('tool_dataflows_step_depends', [
+                'dependson' => $srcid,
+                'stepid' => $destid,
+            ]);
+            if (isset($dependency->position)) {
+                $outputlabel = $srcstep->steptype->get_output_label($dependency->position);
+                $connectionstyles = ['label' => $outputlabel];
+            }
+
+            // Final styles.
+            $finalstyles = array_merge($baseconnectionstyles, $localstyles, $connectionstyles);
 
             $styles = '';
             foreach ($finalstyles as $key => $value) {

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -185,10 +185,11 @@ class step_form extends \core\form\persistent {
 
                 // Prepare and set the (output) connection options for this step.
                 foreach ($availablepositions as $position) {
-                    // TODO: If the step has a defined key / label for this entry, then use that label instead.
+                    // If the step has a defined key / label for this entry, then use that label instead.
                     // For example: 'case #14' could instead be 'case: even number detected'.
-                    $defaultoptionlabel = $position;
-                    $label = "{$step->name} → $defaultoptionlabel"; // TODO: relabel based on 'depends on' step config.
+                    $outputlabel = $step->steptype->get_output_label($position);
+
+                    $label = "{$step->name} → $outputlabel";
                     $options[$step->id . self::$persistentclass::DEPENDS_ON_POSITION_SPLITTER . $position] = $label;
                 }
             } else {

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -343,12 +343,21 @@ class step_form extends \core\form\persistent {
         }
 
         // Check the outputs field to ensure it's in the correct form.
+        // This is required becasue validation only hits this after the config have been converted.
         if (isset($data->config) && empty($errors['config'])) {
             $config = Yaml::parse($data->config, Yaml::PARSE_OBJECT_FOR_MAP);
             if (isset($config->outputs) && is_string($config->outputs)) {
                 // The outputs should always be an object / hash-map. If not, it
                 // contains the error message as to why this is the case.
                 $errors['config_outputs'] = $config->outputs;
+            }
+            $fields = $steptype::form_define_fields();
+            // echo"<pre>";print_r($fields);die;
+            // Check all yaml enabled fields, that they are in the correct expected format.
+            if (isset($config->cases) && is_string($config->cases)) {
+                // The outputs should always be an object / hash-map. If not, it
+                // contains the error message as to why this is the case.
+                $errors['config_cases'] = $config->cases;
             }
         }
 

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -79,6 +79,11 @@ class step_form extends \core\form\persistent {
         // Loop through the steps but only show steps where a connection can be
         // added (or if it's a current dependency).
         foreach ($steps as $step) {
+            // We never want a step to depend on itself.
+            if ($step->id === $persistent->id) {
+                continue;
+            }
+
             [, $maxoutputflows] = $step->steptype->get_number_of_output_flows();
             [, $maxoutputconnectors] = $step->steptype->get_number_of_output_connectors();
             $max = max($maxoutputflows, $maxoutputconnectors);
@@ -140,7 +145,6 @@ class step_form extends \core\form\persistent {
                 $options[$step->id] = $step->name; // Will always set a new value.
             }
         }
-        unset($options[$persistent->id]); // We never want a step to depend on itself.
 
         $select = $mform->addElement(
             'select',

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -159,7 +159,7 @@ class step_form extends \core\form\persistent {
                 $maxposition = null;
                 if ($selectedposition) {
                     $maxposition = $selectedposition;
-                } else {
+                } else if (!empty($dependants)) {
                     $maxposition = max(array_column($dependants, 'position')) + 1;
                 }
 

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -356,12 +356,13 @@ class step_form extends \core\form\persistent {
                 $errors['config_outputs'] = $config->outputs;
             }
             $fields = $steptype::form_define_fields();
-            // echo"<pre>";print_r($fields);die;
-            // Check all yaml enabled fields, that they are in the correct expected format.
-            if (isset($config->cases) && is_string($config->cases)) {
-                // The outputs should always be an object / hash-map. If not, it
-                // contains the error message as to why this is the case.
-                $errors['config_cases'] = $config->cases;
+            foreach ($fields as $field => $fieldconfig) {
+                // Check all yaml enabled fields, that they are in the correct expected format.
+                if (!empty($fieldconfig['yaml']) && isset($config->{$field}) && is_string($config->{$field})) {
+                    // The outputs should always be an object / hash-map. If not, it
+                    // contains the error message as to why this is the case.
+                    $errors["config_{$field}"] = $config->{$field};
+                }
             }
         }
 

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -90,6 +90,13 @@ class step_form extends \core\form\persistent {
                 $takenpositions = array_column($dependants, 'position');
                 $availablepositions = array_diff($allpositions, $takenpositions);
 
+                // Check if the current step is a dependant, and if so, INCLUDE the option (and ensure it is selected).
+                $currentstepid = $persistent->id;
+                if (!empty($currentstepid) && isset($dependants[$currentstepid])) {
+                    $availablepositions[] = $dependants[$currentstepid]->position;
+                    sort($availablepositions);
+                }
+
                 foreach ($availablepositions as $position) {
                     $defaultoptionlabel = "Option #{$position}";
                     $label = "{$step->name} > $defaultoptionlabel"; // TODO: relabel based on 'depends on' step config.

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -224,7 +224,7 @@ class engine {
                     continue;
                 }
 
-                $ispartofsameflow = $stepservice->is_part_of_same_flow(
+                $ispartofsameflow = $stepservice->is_part_of_same_flow_group(
                     current($flowcap->upstreams),
                     current($flowcap2->upstreams)
                 );
@@ -235,7 +235,6 @@ class engine {
 
                     // Remove the flow cap that was merged into the first one. No longer required.
                     unset($flowcap2);
-                    // unset($flowcaps[$key]);
                 }
             }
         }

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -111,9 +111,6 @@ class engine {
     /** @var string Scratch directory for temporary files. */
     protected $scratchdir = null;
 
-    /** @var engine_step Sprevious in the queue */
-    protected $previous = null;
-
     /**
      * Constructs the engine.
      *

--- a/classes/local/execution/engine_flow_cap.php
+++ b/classes/local/execution/engine_flow_cap.php
@@ -63,8 +63,7 @@ class engine_flow_cap extends flow_engine_step {
         try {
             if ($status === engine::STATUS_FLOWING) {
                 foreach ($this->upstreams as $upstream) {
-                    $this->steptype->set_upstream($upstream);
-                    $iterators[] = $this->steptype->get_iterator();
+                    $iterators[] = $this->steptype->get_upstream_iterator($upstream);
                 }
 
                 // Pull down (check) and see if things can flow through. If not, pull down on the next upstream.

--- a/classes/local/execution/engine_flow_cap.php
+++ b/classes/local/execution/engine_flow_cap.php
@@ -28,11 +28,12 @@ namespace tool_dataflows\local\execution;
 class engine_flow_cap extends flow_engine_step {
 
     /**
-     * Description of what this does
+     * Performs the base go handling, without creating and setting an iterator
+     * as the flow cap handles them differently.
      *
-     * @return  int
+     * @return  int status
      */
-    public function go_cap(): int {
+    public function handle_status_for_execution(): int {
         switch ($this->proceed_status()) {
             case self::PROCEED_GO:
                 try {
@@ -55,10 +56,10 @@ class engine_flow_cap extends flow_engine_step {
     /**
      * Attempt to execute the step. If flowing, will run the iterator.
      *
-     * @return int
+     * @return int status
      */
     public function go(): int {
-        $status = $this->go_cap();
+        $status = $this->handle_status_for_execution();
 
         try {
             if ($status === engine::STATUS_FLOWING) {

--- a/classes/local/execution/flow_engine_step.php
+++ b/classes/local/execution/flow_engine_step.php
@@ -56,7 +56,7 @@ class flow_engine_step extends engine_step {
         switch ($this->proceed_status()) {
             case self::PROCEED_GO:
                 try {
-                    $this->iterator = $this->steptype->get_iterator($this);
+                    $this->iterator = $this->steptype->get_iterator();
                     $this->set_status(engine::STATUS_FLOWING);
                 } catch (\Throwable $thrown) {
                     $this->exception = $thrown;

--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -48,9 +48,6 @@ class dataflow_iterator implements iterator {
     /** @var int $iterationcount */
     protected $iterationcount = 0;
 
-    /** @var mixed $caller - which step down the chain requested for this iterator */
-    protected $caller = null;
-
     /**
      * Create an instance of this class.
      *
@@ -135,9 +132,10 @@ class dataflow_iterator implements iterator {
     /**
      * Next item in the stream.
      *
-     * @return object|bool A JSON compatible object, or false if nothing returned.
+     * @param   object $caller The engine step that called this method, internally used to connect outputs.
+     * @return  object|bool A JSON compatible object, or false if nothing returned.
      */
-    public function next($caller) {
+    public function next(object $caller) {
         if ($this->finished) {
             return false;
         }

--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -132,10 +132,10 @@ class dataflow_iterator implements iterator {
     /**
      * Next item in the stream.
      *
-     * @param   object $caller The engine step that called this method, internally used to connect outputs.
-     * @return  object|bool A JSON compatible object, or false if nothing returned.
+     * @param   \stdClass $caller The engine step that called this method, internally used to connect outputs.
+     * @return  \stdClass|bool A JSON compatible \stdClass, or false if nothing returned.
      */
-    public function next(object $caller) {
+    public function next(\stdClass $caller) {
         if ($this->finished) {
             return false;
         }

--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -135,7 +135,7 @@ class dataflow_iterator implements iterator {
      * @param   \stdClass $caller The engine step that called this method, internally used to connect outputs.
      * @return  \stdClass|bool A JSON compatible \stdClass, or false if nothing returned.
      */
-    public function next(\stdClass $caller) {
+    public function next($caller) {
         if ($this->finished) {
             return false;
         }

--- a/classes/local/execution/iterators/iterator.php
+++ b/classes/local/execution/iterators/iterator.php
@@ -57,7 +57,8 @@ interface iterator {
     /**
      * Next item in the stream.
      *
-     * @return object|bool A JSON compatible object, or false if nothing returned.
+     * @param   object $caller The engine step that called this method, internally used to connect outputs.
+     * @return  object|bool A JSON compatible object, or false if nothing returned.
      */
-    public function next($caller);
+    public function next(object $caller);
 }

--- a/classes/local/execution/iterators/iterator.php
+++ b/classes/local/execution/iterators/iterator.php
@@ -57,8 +57,8 @@ interface iterator {
     /**
      * Next item in the stream.
      *
-     * @param   object $caller The engine step that called this method, internally used to connect outputs.
-     * @return  object|bool A JSON compatible object, or false if nothing returned.
+     * @param   \stdClass $caller The engine step that called this method, internally used to connect outputs.
+     * @return  \stdClass|bool A JSON compatible \stdClass, or false if nothing returned.
      */
-    public function next(object $caller);
+    public function next(\stdClass $caller);
 }

--- a/classes/local/execution/iterators/iterator.php
+++ b/classes/local/execution/iterators/iterator.php
@@ -60,5 +60,5 @@ interface iterator {
      * @param   \stdClass $caller The engine step that called this method, internally used to connect outputs.
      * @return  \stdClass|bool A JSON compatible \stdClass, or false if nothing returned.
      */
-    public function next(\stdClass $caller);
+    public function next($caller);
 }

--- a/classes/local/execution/iterators/iterator.php
+++ b/classes/local/execution/iterators/iterator.php
@@ -59,5 +59,5 @@ interface iterator {
      *
      * @return object|bool A JSON compatible object, or false if nothing returned.
      */
-    public function next();
+    public function next($caller);
 }

--- a/classes/local/service/step_service.php
+++ b/classes/local/service/step_service.php
@@ -38,15 +38,15 @@ class step_service {
      * @param   engine_step $enginestep2
      * @return  bool
      */
-    public function is_part_of_same_flow(engine_step $enginestep1, engine_step $enginestep2): bool {
+    public function is_part_of_same_flow_group(engine_step $enginestep1, engine_step $enginestep2): bool {
         return true; // TODO: actually check.
     }
 
     /**
      * Merges the flow caps within the same flow group such that the flow group has a shared flow cap.
      *
-     * @param   flow_cap $flowcap
-     * @param   array $upstreams
+     * @param  engine_flow_cap $flowcap
+     * @param  array $upstreams
      */
     public function consolidate_flowcaps(engine_flow_cap $flowcap, array $upstreams) {
         foreach ($upstreams as $enginestep) {
@@ -54,6 +54,4 @@ class step_service {
             $flowcap->upstreams[$enginestep->id] = $enginestep;
         }
     }
-
-
 }

--- a/classes/local/service/step_service.php
+++ b/classes/local/service/step_service.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\service;
+
+use tool_dataflows\local\execution\engine_flow_cap;
+use tool_dataflows\local\execution\engine_step;
+
+/**
+ * Step Service
+ *
+ * Handles some domain logic for how steps should interact with each other.
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class step_service {
+
+    /**
+     * Returns whether or not the given engine step, is part of the same flow group.
+     *
+     * @param   engine_step $enginestep1
+     * @param   engine_step $enginestep2
+     * @return  bool
+     */
+    public function is_part_of_same_flow(engine_step $enginestep1, engine_step $enginestep2): bool {
+        return true; // TODO: actually check.
+    }
+
+    /**
+     * Merges the flow caps within the same flow group such that the flow group has a shared flow cap.
+     *
+     * @param   flow_cap $flowcap
+     * @param   array $upstreams
+     */
+    public function consolidate_flowcaps(engine_flow_cap $flowcap, array $upstreams) {
+        foreach ($upstreams as $enginestep) {
+            $enginestep->downstreams['puller'] = $flowcap;
+            $flowcap->upstreams[$enginestep->id] = $enginestep;
+        }
+    }
+
+
+}

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -148,7 +148,7 @@ abstract class base_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'config' => ['type' => PARAM_TEXT, 'default' => ''],
         ];
@@ -373,18 +373,22 @@ abstract class base_step {
      * @return  \stdClass
      */
     public function form_get_default_data(\stdClass $data): \stdClass {
+        // Get the fields configuration array.
+        $fields = static::form_define_fields();
+
         $yaml = Yaml::parse($data->config, Yaml::PARSE_OBJECT_FOR_MAP) ?? new \stdClass;
         foreach ($yaml as $key => $value) {
             $data->{"config_$key"} = $value;
-        }
-        // Handling for "outputs".
-        if (isset($yaml->outputs)) {
-            $data->config_outputs = Yaml::dump(
-                $yaml->outputs,
-                helper::YAML_DUMP_INLINE_LEVEL,
-                helper::YAML_DUMP_INDENT_LEVEL,
-                Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | YAML::DUMP_OBJECT_AS_MAP
-            );
+
+            if ($key === 'outputs' || !empty($fields[$key]['yaml'])) {
+                // Handling for "outputs", and fields marked as yaml-enabled.
+                $data->{"config_$key"} = Yaml::dump(
+                    $value,
+                    helper::YAML_DUMP_INLINE_LEVEL,
+                    helper::YAML_DUMP_INDENT_LEVEL,
+                    Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | YAML::DUMP_OBJECT_AS_MAP
+                );
+            }
         }
         return $data;
     }
@@ -401,10 +405,10 @@ abstract class base_step {
         $fields = static::form_define_fields();
 
         // Add in the outputs field.
-        $fields += ['outputs' => []];
+        $fields += ['outputs' => ['yaml' => true]];
 
         $config = [];
-        foreach ($fields as $fieldname => $unused) {
+        foreach ($fields as $fieldname => $fieldconfig) {
             $datafield = "config_$fieldname";
             if (!property_exists($data, $datafield)) {
                 continue;
@@ -415,7 +419,7 @@ abstract class base_step {
             $config[$fieldname] = str_replace("\r\n", "\n", $config[$fieldname]);
 
             // Handle outputs (convert to a proper data structure).
-            if ($fieldname === 'outputs') {
+            if (!empty($fieldconfig['yaml'])) {
                 // Attempt to convert the data to the appropriate format. Due to
                 // persistent handling, validation happens at a differnt point
                 // in time from data conversion and so it is a bit disconnected.

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -552,4 +552,31 @@ abstract class base_step {
     public function set_variables(string $name, $value) {
         $this->variables[$name] = $value;
     }
+
+    /**
+     * Returns a list of labels available for a given step
+     *
+     * By default, this would be the position / order of each connected output
+     * (and show as a number). Each case can however based on its own
+     * configuration handling, determine the label it chooses to set and display
+     * for the output connection. This will only be used and called if there are
+     * more than one expected output.
+     *
+     * @return  array of labels defined for this step type
+     */
+    public function get_output_labels(): array {
+        return [];
+    }
+
+    /**
+     * Returns the output (connection / link) label
+     *
+     * @param   int $position of the output connection
+     * @return  string $label
+     */
+    public function get_output_label(int $position): string {
+        $labels = $this->get_output_labels();
+        $label = $labels[$position] ?? (string) $position;
+        return $label;
+    }
 }

--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -39,7 +39,7 @@ class connector_curl extends connector_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'curl' => ['type' => PARAM_TEXT],
             'destination' => ['type' => PARAM_PATH],

--- a/classes/local/step/connector_debug_file_display.php
+++ b/classes/local/step/connector_debug_file_display.php
@@ -50,7 +50,7 @@ class connector_debug_file_display extends connector_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'streamname' => ['type' => PARAM_TEXT],
         ];

--- a/classes/local/step/connector_s3.php
+++ b/classes/local/step/connector_s3.php
@@ -40,7 +40,7 @@ class connector_s3 extends connector_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'bucket'            => ['type' => PARAM_TEXT, 'required' => true],
             'region'            => ['type' => PARAM_TEXT, 'required' => true],

--- a/classes/local/step/connector_sns_notify.php
+++ b/classes/local/step/connector_sns_notify.php
@@ -36,7 +36,7 @@ class connector_sns_notify extends connector_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'region'  => ['type' => PARAM_TEXT, 'required' => true],
             'key'     => ['type' => PARAM_TEXT], // Empty if using sdk credentials.

--- a/classes/local/step/flow_cap.php
+++ b/classes/local/step/flow_cap.php
@@ -19,6 +19,8 @@ namespace tool_dataflows\local\step;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\engine_flow_cap;
 use tool_dataflows\local\execution\engine_step;
+use tool_dataflows\local\execution\iterators\iterator;
+use tool_dataflows\local\execution\iterators\dataflow_iterator;
 
 /**
  * A special, virtual flow step that is attached to the end of a flow block.
@@ -38,5 +40,25 @@ final class flow_cap extends flow_step {
      */
     protected function generate_engine_step(engine $engine): engine_step {
         return new engine_flow_cap($engine, $this->stepdef, $this);
+    }
+
+    /**
+     * Description of what this does
+     */
+    public function set_upstream($upstream) {
+        $this->upstream = $upstream;
+    }
+
+    /**
+     * Get the iterator for the step, based on configurations.
+     *
+     * @return iterator
+     */
+    public function get_iterator(): iterator {
+        $upstream = $this->upstream;
+        if ($upstream === false || !$upstream->is_flow()) {
+            throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
+        }
+        return new dataflow_iterator($this->enginestep, $upstream->iterator);
     }
 }

--- a/classes/local/step/flow_cap.php
+++ b/classes/local/step/flow_cap.php
@@ -19,6 +19,7 @@ namespace tool_dataflows\local\step;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\engine_flow_cap;
 use tool_dataflows\local\execution\engine_step;
+use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\execution\iterators\iterator;
 use tool_dataflows\local\execution\iterators\dataflow_iterator;
 
@@ -43,10 +44,16 @@ final class flow_cap extends flow_step {
     }
 
     /**
-     * Description of what this does
+     * Gets the iterator for this particular upstream.
+     *
+     * This returns different next steps/handlers depending on the upstream path.
+     *
+     * @param  flow_engine_step $upstream
+     * @return iterator
      */
-    public function set_upstream($upstream) {
+    public function get_upstream_iterator(flow_engine_step $upstream): iterator {
         $this->upstream = $upstream;
+        return $this->get_iterator();
     }
 
     /**

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -41,4 +41,27 @@ class flow_logic_case extends flow_logic_step {
      * @var int[] number of output flows (min, max)
      */
     protected $outputflows = [2, 20];
+
+    /**
+     * Returns a list of labels available for a given step
+     *
+     * By default, this would be the position / order of each connected output
+     * (and show as a number). Each case can however based on its own
+     * configuration handling, determine the label it chooses to set and display
+     * for the output connection. This will only be used and called if there are
+     * more than one expected output.
+     *
+     * @return  array of labels defined for this step type
+     */
+    public function get_output_labels(): array {
+        // Based on configuration, the list of outputs, depends on the list of expressions defined.
+        return [
+            'even',
+            'odd',
+            'simple',
+            'complex',
+            'chaos',
+            'disorder',
+        ];
+    }
 }

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -193,8 +193,8 @@ class flow_logic_case extends flow_logic_step {
 
                 $casenumber = $this->stepcasemap[$caller->step->id];
                 $case = $this->cases[$casenumber] ?? null;
-                if (!$case) {
-                    throw new \moodle_exception(get_string('casenotfound', 'tool_dataflows'));
+                if (!isset($case)) {
+                    throw new \moodle_exception(get_string('flow_logic_case:casenotfound', 'tool_dataflows', $casenumber));
                 }
 
                 $parser = new parser;

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -54,15 +54,19 @@ class flow_logic_case extends flow_logic_step {
      * @return  array of labels defined for this step type
      */
     public function get_output_labels(): array {
-        // Based on configuration, the list of outputs, depends on the list of expressions defined.
-        return [
-            'even',
-            'odd',
-            'simple',
-            'complex',
-            'chaos',
-            'disorder',
-        ];
+        $cases = $this->stepdef->config->cases ?? null;
+        if (!$cases) {
+            return [];
+        }
+
+        // Currently since the positions start at 1, it will need to be set as such accordingly.
+        // Depending on DX this may change.
+        $labels = [];
+        $position = 1;
+        foreach ($cases as $key => $unused) {
+            $labels[$position++] = $key;
+        }
+        return $labels;
     }
 
     /**

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -14,9 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Flow logic: case
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows\local\step;
 
-use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\execution\iterators\dataflow_iterator;
 use tool_dataflows\local\execution\iterators\iterator;
@@ -127,14 +135,16 @@ class flow_logic_case extends flow_logic_step {
          */
         return new class($this->enginestep, $upstream->iterator) extends dataflow_iterator {
 
+            /** @var array of different cases */
             private $cases = [];
+
+            /** @var array mapping of step to cases, [step.id => case index] */
             private $stepcasemap = [];
 
             /**
              * Create an instance of this class.
              *
              * @param  flow_engine_step $step
-             * @param  object $config
              * @param  iterator $input
              */
             public function __construct(flow_engine_step $step, iterator $input) {
@@ -164,6 +174,8 @@ class flow_logic_case extends flow_logic_step {
              * value from the iterator, or if the case 'matches'.
              *
              * For all other cases, return false|null which indicates no value to pull from at this stage.
+             *
+             * @param flow_engine_step $caller
              */
             public function next($caller) {
                 if ($this->finished) {

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -41,16 +41,14 @@ use tool_dataflows\parser;
 class flow_logic_case extends flow_logic_step {
 
     /**
-     * For a join step, it should have 2 or more inputs and for now, up to 20
-     * possible input flows.
+     * For this step, it should have a maximum of 1 input flow.
      *
      * @var int[] number of input flows (min, max)
      */
     protected $inputflows = [1, 1];
 
     /**
-     * For a join step, there should be exactly one output. This is because
-     * without at least one output, there is no need to perform a join.
+     * For this step, it should have 2 or more inputs and for now, up to 20.
      *
      * @var int[] number of output flows (min, max)
      */
@@ -109,7 +107,14 @@ class flow_logic_case extends flow_logic_step {
             'textarea',
             'config_cases',
             get_string('flow_logic_case:cases', 'tool_dataflows'),
-            ['cols' => 50, 'rows' => $maxoutputs, 'placeholder' => "label: <expression>\nsome other label: <expression>"]
+            [
+                'cols' => 50,
+                // Maxoutputs is too big for normal user. In most cases it will
+                // be 3-5, but if there is N expressions saved then it should be
+                // N+2 so always room for more, up to the maximum (e.g. 20).
+                'rows' => min($maxoutputs, count($this->get_output_labels()) + 2),
+                'placeholder' => "label: <expression>\nsome other label: <expression>"
+            ]
         );
         // Help text for the cases input: Showing a small example, that
         // everything on the right side is an expression by default so does not

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -108,12 +108,12 @@ class flow_logic_case extends flow_logic_step {
             'config_cases',
             get_string('flow_logic_case:cases', 'tool_dataflows'),
             [
+                'placeholder' => "label: <expression>\nsome other label: <expression>",
                 'cols' => 50,
                 // Maxoutputs is too big for normal user. In most cases it will
                 // be 3-5, but if there is N expressions saved then it should be
                 // N+2 so always room for more, up to the maximum (e.g. 20).
                 'rows' => min($maxoutputs, count($this->get_output_labels()) + 2),
-                'placeholder' => "label: <expression>\nsome other label: <expression>"
             ]
         );
         // Help text for the cases input: Showing a small example, that
@@ -152,11 +152,6 @@ class flow_logic_case extends flow_logic_step {
              * @param  iterator $input
              */
             public function __construct(flow_engine_step $step, iterator $input) {
-                // TODO: pull conditions out, and also internally line up each
-                // 'case' with the expected step that is asking for the input.
-                // To later determine who to provide the input to and who to
-                // ignore.
-
                 // Prepare and map output number, with expected step.id.
                 $cases = array_values((array) $step->stepdef->config->cases);
                 $this->cases = $cases;

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -64,4 +64,39 @@ class flow_logic_case extends flow_logic_step {
             'disorder',
         ];
     }
+
+    /**
+     * Return the definition of the fields available in this form.
+     *
+     * @return array
+     */
+    public static function form_define_fields(): array {
+        return [
+            'cases' => ['type' => PARAM_TEXT, 'required' => true, 'yaml' => true],
+        ];
+    }
+
+    /**
+     * Allows each step type to determine a list of optional/required form
+     * inputs for their configuration
+     *
+     * It's recommended you prefix the additional config related fields to avoid
+     * conflicts with any existing fields.
+     *
+     * @param \MoodleQuickForm $mform
+     */
+    public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
+        // TODO: Fix this number.
+        $maxoutputs = 20;
+        $mform->addElement(
+            'textarea',
+            'config_cases',
+            get_string('flow_logic_case:cases', 'tool_dataflows'),
+            ['cols' => 50, 'rows' => $maxoutputs, 'placeholder' => "label: <expression>\nsome other label: <expression>"]
+        );
+        // Help text for the cases input: Showing a small example, that
+        // everything on the right side is an expression by default so does not
+        // require the ${{ }}, and lists the current mappings.
+        // TODO: Implement.
+    }
 }

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -174,7 +174,7 @@ class flow_logic_case extends flow_logic_step {
              *
              * For all other cases, return false|null which indicates no value to pull from at this stage.
              *
-             * @param flow_engine_step $caller
+             * @param \stdClass $caller
              */
             public function next($caller) {
                 if ($this->finished) {

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\step;
+
+/**
+ * Flow logic: case
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class flow_logic_case extends flow_logic_step {
+
+    /**
+     * For a join step, it should have 2 or more inputs and for now, up to 20
+     * possible input flows.
+     *
+     * @var int[] number of input flows (min, max)
+     */
+    protected $inputflows = [1, 1];
+
+    /**
+     * For a join step, there should be exactly one output. This is because
+     * without at least one output, there is no need to perform a join.
+     *
+     * @var int[] number of output flows (min, max)
+     */
+    protected $outputflows = [2, 20];
+}

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -104,8 +104,7 @@ class flow_logic_case extends flow_logic_step {
      * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
-        // TODO: Fix this number.
-        $maxoutputs = 20;
+        [, $maxoutputs] = $this->outputflows;
         $mform->addElement(
             'textarea',
             'config_cases',
@@ -115,7 +114,7 @@ class flow_logic_case extends flow_logic_step {
         // Help text for the cases input: Showing a small example, that
         // everything on the right side is an expression by default so does not
         // require the ${{ }}, and lists the current mappings.
-        // TODO: Implement.
+        $mform->addElement('static', 'config_cases_help', '', get_string('flow_logic_case:cases_help', 'tool_dataflows'));
     }
 
     /**

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -78,7 +78,6 @@ abstract class flow_step extends base_step {
      * @return iterator
      */
     public function get_iterator(): iterator {
-        // Default is to simply map.
         $upstream = current($this->enginestep->upstreams);
         if ($upstream === false || !$upstream->is_flow()) {
             throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));

--- a/classes/local/step/reader_json.php
+++ b/classes/local/step/reader_json.php
@@ -43,7 +43,7 @@ class reader_json extends reader_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'pathtojson' => ['type' => PARAM_TEXT],
             'arrayexpression' => ['type' => PARAM_TEXT],

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -45,7 +45,7 @@ class reader_sql extends reader_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'sql' => ['type' => PARAM_TEXT],
             'counterfield' => ['type' => PARAM_TEXT],

--- a/classes/local/step/reader_step.php
+++ b/classes/local/step/reader_step.php
@@ -16,9 +16,6 @@
 
 namespace tool_dataflows\local\step;
 
-use tool_dataflows\local\execution\iterators\iterator;
-use tool_dataflows\local\execution\iterators\dataflow_iterator;
-
 /**
  * Base class for reader step types.
  *
@@ -34,20 +31,6 @@ abstract class reader_step extends flow_step {
 
     /** @var int[] number of output connectors (min, max). */
     protected $inputconnectors = [0, 1];
-
-    /**
-     * Get the iterator for the step, based on configurations.
-     *
-     * @return iterator
-     */
-    public function get_iterator(): iterator {
-        // Default is to simply map.
-        $upstream = current($this->enginestep->upstreams);
-        if ($upstream === false || !$upstream->is_flow()) {
-            throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
-        }
-        return new dataflow_iterator($this->enginestep, $upstream->iterator);
-    }
 
     /**
      * {@inheritdoc}

--- a/classes/local/step/trigger_cron.php
+++ b/classes/local/step/trigger_cron.php
@@ -34,7 +34,7 @@ class trigger_cron extends trigger_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'minute' => ['type' => PARAM_TEXT],
             'hour' => ['type' => PARAM_TEXT],

--- a/classes/local/step/trigger_step.php
+++ b/classes/local/step/trigger_step.php
@@ -50,20 +50,6 @@ abstract class trigger_step extends connector_step {
     }
 
     /**
-     * Get the iterator for the step, based on configurations.
-     *
-     * @return iterator
-     */
-    public function get_iterator(): iterator {
-        // Default is to simply map.
-        $upstream = current($this->enginestep->upstreams);
-        if ($upstream === false || !$upstream->is_flow()) {
-            throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
-        }
-        return new dataflow_iterator($this->enginestep, $upstream->iterator);
-    }
-
-    /**
      * {@inheritdoc}
      */
     final public function get_group(): string {

--- a/classes/local/step/writer_step.php
+++ b/classes/local/step/writer_step.php
@@ -16,10 +16,6 @@
 
 namespace tool_dataflows\local\step;
 
-use tool_dataflows\local\execution\iterators\iterator;
-use tool_dataflows\local\execution\iterators\dataflow_iterator;
-use tool_dataflows\local\execution\flow_engine_step;
-
 /**
  * Base class for writer step types.
  *
@@ -41,20 +37,6 @@ abstract class writer_step extends flow_step {
 
     /** @var bool whether or not this step type (potentially) contains a side effect or not */
     protected $hassideeffect = true;
-
-    /**
-     * Get the iterator for the step, based on configurations.
-     *
-     * @return  data_iterator
-     */
-    public function get_iterator(): iterator {
-        // Default is to simply map.
-        $upstream = current($this->enginestep->upstreams);
-        if ($upstream === false || !$upstream->is_flow()) {
-            throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
-        }
-        return new dataflow_iterator($this->enginestep, $upstream->iterator);
-    }
 
     /**
      * {@inheritdoc}

--- a/classes/local/step/writer_stream.php
+++ b/classes/local/step/writer_stream.php
@@ -53,7 +53,7 @@ class writer_stream extends writer_step {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'streamname' => ['type' => PARAM_TEXT],
             'format' => ['type' => PARAM_TEXT],

--- a/classes/step.php
+++ b/classes/step.php
@@ -37,7 +37,7 @@ class step extends persistent {
     /** The table name. */
     const TABLE = 'tool_dataflows_steps';
 
-    const DEPENDS_ON_POSITION_SPLITTER = '::';
+    const DEPENDS_ON_POSITION_SPLITTER = ':';
 
     /** @var array $dependson */
     private $dependson = [];
@@ -309,8 +309,10 @@ class step extends persistent {
             // the expected id numeric value.
             $dependson = $dependency->id ?? $dependency;
             if (gettype($dependson) === 'string' && !is_number($dependson)) {
+                // TODO: Split this into its own method + add tests.
                 // Resolve the actual dependency to an ID and if required, a position.
-                $regex = '/(?<id>([a-z]*\d*))(' . self::DEPENDS_ON_POSITION_SPLITTER . '(?<position>\d+))?/m';
+                $regex = '/(?<id>([^' . self::DEPENDS_ON_POSITION_SPLITTER . '\n])+)' .
+                    '(' . self::DEPENDS_ON_POSITION_SPLITTER . '(?<position>\d+))?/m';
                 preg_match_all($regex, $dependson, $matches, PREG_SET_ORDER, 0);
                 if (empty($matches)) {
                     throw new moodle_exception('stepdependencydoesnotexist', 'tool_dataflows', '', $dependson);

--- a/classes/step.php
+++ b/classes/step.php
@@ -619,6 +619,10 @@ class step extends persistent {
         $fn = "get_number_of_{$inputoutput}_{$flowconnector}s";
         $steptype = $this->steptype;
         [$min, $max] = $steptype->$fn();
+        if ($inputoutput === 'output') {
+            $min = max($min, count($steptype->get_output_labels()));
+        }
+
         if ($count < $min || $count > $max) {
             return [
                 "invalid_count_{$inputoutput}{$flowconnector}s_{$this->id}" => get_string(

--- a/classes/step.php
+++ b/classes/step.php
@@ -501,7 +501,12 @@ class step extends persistent {
         $dependencies = $this->dependencies();
         if (!empty($dependencies)) {
             // Since this field can be a single string or an array of aliases, it should be checked beforehand.
-            $aliases = array_column($dependencies, 'alias');
+            $aliases = array_map(function ($dependency) {
+                if (isset($dependency->position)) {
+                    return $dependency->alias . self::DEPENDS_ON_POSITION_SPLITTER . $dependency->position;
+                }
+                return $dependency->alias;
+            }, $dependencies);
 
             // Simplify into a single value if there is only a single entry.
             $aliases = isset($aliases[1]) ? $aliases : reset($aliases);

--- a/classes/step.php
+++ b/classes/step.php
@@ -37,6 +37,7 @@ class step extends persistent {
     /** The table name. */
     const TABLE = 'tool_dataflows_steps';
 
+    /** Delimeter for the 'depends on' and 'position' values. */
     const DEPENDS_ON_POSITION_SPLITTER = ':';
 
     /** @var array $dependson */

--- a/classes/step.php
+++ b/classes/step.php
@@ -310,7 +310,7 @@ class step extends persistent {
             $dependson = $dependency->id ?? $dependency;
             if (gettype($dependson) === 'string' && !is_number($dependson)) {
                 // Resolve the actual dependency to an ID and if required, a position.
-                $regex = '/(?<id>\d+)(' . self::DEPENDS_ON_POSITION_SPLITTER . '(?<position>\d+))?/m';
+                $regex = '/(?<id>([a-z]*\d*))(' . self::DEPENDS_ON_POSITION_SPLITTER . '(?<position>\d+))?/m';
                 preg_match_all($regex, $dependson, $matches, PREG_SET_ORDER, 0);
                 if (empty($matches)) {
                     throw new moodle_exception('stepdependencydoesnotexist', 'tool_dataflows', '', $dependson);

--- a/classes/step.php
+++ b/classes/step.php
@@ -368,9 +368,9 @@ class step extends persistent {
     /**
      * Returns a list of other steps that depend on this step before they can run.
      *
-     * @return     array step dependencies
+     * @return  array step dependencies
      */
-    public function dependants() {
+    public function dependants(): array {
         global $DB;
         $sql = "SELECT step.id,
                        step.name,
@@ -384,7 +384,7 @@ class step extends persistent {
         $deps = $DB->get_records_sql($sql, [
             'dependson' => $this->id,
         ]);
-        return $deps;
+        return $deps ?? [];
     }
 
     /**

--- a/classes/steps_table.php
+++ b/classes/steps_table.php
@@ -169,7 +169,13 @@ class steps_table extends \table_sql {
         // Make the list.
         $out = \html_writer::start_tag('ul');
         foreach ($deps as $dep) {
-            $out .= \html_writer::tag('li', $dep->name);
+            $label = "{$dep->name}";
+            if (isset($dep->position)) {
+                // TODO: If the step has a defined key / label for this entry, then use that label instead.
+                // For example: 'case #14' could instead be 'case: even number detected'.
+                $label .= " → {$dep->position}";
+            }
+            $out .= \html_writer::tag('li', $label);
         }
         $out .= \html_writer::end_tag('ul');
         return $out;

--- a/classes/steps_table.php
+++ b/classes/steps_table.php
@@ -171,9 +171,16 @@ class steps_table extends \table_sql {
         foreach ($deps as $dep) {
             $label = "{$dep->name}";
             if (isset($dep->position)) {
-                // TODO: If the step has a defined key / label for this entry, then use that label instead.
+                // If the step has a defined key / label for this entry, then use that label instead.
                 // For example: 'case #14' could instead be 'case: even number detected'.
-                $label .= " → {$dep->position}";
+                $outputlabel = $dep->position;
+                if (isset($dep->type) && class_exists($dep->type)) {
+                    $depstep = new step($dep->id);
+                    $steptype = $depstep->steptype;
+                    $outputlabel = $steptype->get_output_label($dep->position);
+                }
+
+                $label .= " → {$outputlabel}";
             }
             $out .= \html_writer::tag('li', $label);
         }

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -392,7 +392,13 @@ class visualiser {
     protected static function get_link_limit(base_step $steptype, string $inputoutput, string $flowconnector): string {
         $fn = "get_number_of_{$inputoutput}_{$flowconnector}s";
         list($min, $max) = $steptype->$fn();
-        if ($min == $max) {
+
+        // Consider output label counts.
+        if ($inputoutput === 'output') {
+            $min = max($min, count($steptype->get_output_labels()));
+        }
+
+        if ($min === $max) {
             if ($min > 1) {
                 return get_string("{$inputoutput}_{$flowconnector}_link_limit_plural", 'tool_dataflows', $min);
             } else if ($min > 0) {

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/dataflows/db" VERSION="20220718" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
+<XMLDB PATH="admin/tool/dataflows/db" VERSION="20220720" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -48,6 +48,7 @@
       <FIELDS>
         <FIELD NAME="stepid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="dependson" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="References the step that the stepid depends on"/>
+        <FIELD NAME="position" TYPE="int" LENGTH="4" NOTNULL="false" SEQUENCE="false" COMMENT="The order of the dependencies, which only apply for those with varying number of outputs"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="stepid_dependson" TYPE="unique" FIELDS="stepid, dependson"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -82,5 +82,20 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022071900, 'tool', 'dataflows');
     }
 
+    if ($oldversion < 2022072101) {
+
+        // Define field position to be added to tool_dataflows_step_depends.
+        $table = new xmldb_table('tool_dataflows_step_depends');
+        $field = new xmldb_field('position', XMLDB_TYPE_INTEGER, '4', null, null, null, null, 'dependson');
+
+        // Conditionally launch add field position.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Dataflows savepoint reached.
+        upgrade_plugin_savepoint(true, 2022072101, 'tool', 'dataflows');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -82,7 +82,7 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022071900, 'tool', 'dataflows');
     }
 
-    if ($oldversion < 2022072101) {
+    if ($oldversion < 2022072502) {
 
         // Define field position to be added to tool_dataflows_step_depends.
         $table = new xmldb_table('tool_dataflows_step_depends');
@@ -94,7 +94,7 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         }
 
         // Dataflows savepoint reached.
-        upgrade_plugin_savepoint(true, 2022072101, 'tool', 'dataflows');
+        upgrade_plugin_savepoint(true, 2022072502, 'tool', 'dataflows');
     }
 
     return true;

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -97,7 +97,8 @@ $string['step_name_connector_curl'] = 'Curl connector';
 $string['step_name_connector_debugging'] = 'Debugging connector';
 $string['step_name_connector_s3'] = 'S3 file copy connector';
 $string['step_name_connector_sns_notify'] = 'AWS SNS Notification';
-$string['step_name_flow_logic_join'] = 'Flow join';
+$string['step_name_flow_logic_case'] = 'Case';
+$string['step_name_flow_logic_join'] = 'Join';
 $string['step_name_flow_transformer_filter'] = 'Filter transformer';
 $string['step_name_reader_json'] = 'JSON reader';
 $string['step_name_reader_sql'] = 'SQL reader';
@@ -112,9 +113,9 @@ $string['stepgroupconnectors'] = 'Connectors';
 $string['stepgroupconnectorlogics'] = 'Connector Logics';
 $string['stepgroupwriters'] = 'Writers';
 $string['stepgroupflowtransformers'] = 'Flow Transformers';
-$string['stepgroupflowlogics'] = 'Flow steps';
+$string['stepgroupflowlogics'] = 'Flow logic';
 $string['stepgroupflows'] = 'Flows';
-$string['stepgroupreaders'] = 'Reader steps';
+$string['stepgroupreaders'] = 'Readers';
 
 // Step (form).
 $string['available_fields'] = 'Available Fields';

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -327,3 +327,4 @@ $string['check:dataflows_run_status'] = 'Run {$a->name} - {$a->state}';
 // Flow logic: Case.
 $string['flow_logic_case:cases'] = 'Cases';
 $string['flow_logic_case:cases_help'] = 'Each line represents a case, and each case has a label for display, and an expression separated by a colon "<code>:</code>", used to determine whether the linked step will consume the data that flows or not. If no label is present, it will instead the line number for that connection.';
+$string['flow_logic_case:casenotfound'] = 'The output position of #{$a} did not match any existing case';

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -323,3 +323,6 @@ $string['check:dataflows_completed_successfully'] = 'All recent dataflow runs co
 $string['check:dataflows_no_runs'] = 'No dataflow runs executed.';
 $string['check:dataflows_not_enabled'] = 'No dataflows enabled.';
 $string['check:dataflows_run_status'] = 'Run {$a->name} - {$a->state}';
+
+// Flow logic: Case.
+$string['flow_logic_case:cases'] = 'Cases';

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -326,3 +326,4 @@ $string['check:dataflows_run_status'] = 'Run {$a->name} - {$a->state}';
 
 // Flow logic: Case.
 $string['flow_logic_case:cases'] = 'Cases';
+$string['flow_logic_case:cases_help'] = 'Each line represents a case, and each case has a label for display, and an expression separated by a colon "<code>:</code>", used to determine whether the linked step will consume the data that flows or not. If no label is present, it will instead the line number for that connection.';

--- a/lib.php
+++ b/lib.php
@@ -54,6 +54,7 @@ function tool_dataflows_step_types() {
         new step\reader_json,
         new step\writer_debugging,
         new step\flow_logic_join,
+        new step\flow_logic_case,
         new step\writer_stream,
         new step\connector_debugging,
         new step\connector_debug_file_display,

--- a/step.php
+++ b/step.php
@@ -91,7 +91,13 @@ if ($form->is_cancelled()) {
 
 // Populate the foreign dependencies data if there was any.
 if (!empty($dependencies)) {
-    $form->set_data(['dependson' => array_column($dependencies, 'id')]);
+    $dependsonoptions = array_map(function ($dependency) {
+        if ($dependency->position) {
+            return $dependency->id . step::DEPENDS_ON_POSITION_SPLITTER . $dependency->position;
+        }
+        return $dependency->id;
+    }, $dependencies);
+    $form->set_data(['dependson' => $dependsonoptions]);
 }
 
 if (($data = $form->get_data())) {

--- a/tests/local/execution/array_in_type.php
+++ b/tests/local/execution/array_in_type.php
@@ -42,8 +42,8 @@ class array_in_type extends reader_step {
      *
      * @return iterator
      */
-    public function get_iterator(): iterator {
-        return new dataflow_iterator($this->enginestep, new \ArrayIterator(self::$source));
+    public function get_iterator($caller = null): iterator {
+        return new dataflow_iterator($this->enginestep, new \ArrayIterator(self::$source), $caller);
     }
 
     /**

--- a/tests/local/execution/array_in_type.php
+++ b/tests/local/execution/array_in_type.php
@@ -42,8 +42,8 @@ class array_in_type extends reader_step {
      *
      * @return iterator
      */
-    public function get_iterator($caller = null): iterator {
-        return new dataflow_iterator($this->enginestep, new \ArrayIterator(self::$source), $caller);
+    public function get_iterator(): iterator {
+        return new dataflow_iterator($this->enginestep, new \ArrayIterator(self::$source));
     }
 
     /**

--- a/tests/local/execution/array_out_type.php
+++ b/tests/local/execution/array_out_type.php
@@ -39,9 +39,9 @@ class array_out_type extends writer_step {
      *
      * @return iterator
      */
-    public function get_iterator($caller = null): iterator {
+    public function get_iterator(): iterator {
         $input = current($this->enginestep->upstreams)->iterator;
-        return new dataflow_iterator($this->enginestep, $input, $caller);
+        return new dataflow_iterator($this->enginestep, $input);
     }
 
     /**

--- a/tests/local/execution/array_out_type.php
+++ b/tests/local/execution/array_out_type.php
@@ -39,9 +39,9 @@ class array_out_type extends writer_step {
      *
      * @return iterator
      */
-    public function get_iterator(): iterator {
+    public function get_iterator($caller = null): iterator {
         $input = current($this->enginestep->upstreams)->iterator;
-        return new dataflow_iterator($this->enginestep, $input);
+        return new dataflow_iterator($this->enginestep, $input, $caller);
     }
 
     /**

--- a/tests/local/execution/reader_sql_variable_setter.php
+++ b/tests/local/execution/reader_sql_variable_setter.php
@@ -39,7 +39,7 @@ class reader_sql_variable_setter extends reader_sql {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return array_merge(
             parent::form_define_fields(),
             [

--- a/tests/tool_dataflows_flow_logic_case_test.php
+++ b/tests/tool_dataflows_flow_logic_case_test.php
@@ -1,0 +1,160 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+use Symfony\Component\Yaml\Yaml;
+use tool_dataflows\local\execution\engine;
+use tool_dataflows\local\step\flow_logic_case;
+use tool_dataflows\local\step\writer_stream;
+use tool_dataflows\local\execution\array_in_type;
+
+// This is needed. File will not be automatically included.
+require_once(__DIR__ . '/local/execution/array_in_type.php');
+
+/**
+ * Unit tests for flow_logic_case step.
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_flow_logic_case_test extends \advanced_testcase {
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Dataflow creation helper function
+     *
+     * @return  array of the resulting dataflow and steps in the format [dataflow, steps]
+     */
+    public function create_dataflow() {
+        $dataflow = new dataflow();
+        $dataflow->name = 'case step test';
+        $dataflow->enabled = true;
+        $dataflow->save();
+
+        /*
+         * To test case steps, we ideally want at least a branch in the flow,
+         * that is more than one level deep on both sides, and a check to ensure
+         * the results are different. Note there is a 'reader' before the case step.
+         *
+         * ┌────────►  number even ───────► even.csv
+         * Case
+         * └────────►  number odd  ───────► odds.csv
+         *
+         * As shown in the example above.
+        */
+
+        $steps = [];
+
+        // Reader step.
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = array_in_type::class;
+        $dataflow->add_step($reader);
+
+        // Define the reader records / inputs.
+        $source = [];
+        // Set up the reader with 5 ones, and 4 zeros. Then randomise the order because ultimately, it shouldn't matter.
+        array_push($source, ...array_fill(0, 5, 1));
+        array_push($source, ...array_fill(0, 4, 0));
+
+        // Randomise the order - since it shouldn't matter.
+        shuffle($source);
+
+        // Convert the flat array into an array of objects, holding the key of 'value', for the reader.
+        array_in_type::$source = array_map(function ($value) {
+            return ['value' => $value];
+        }, $source);
+
+        // Case step.
+        $case = new step();
+        $case->name = 'case';
+        $case->type = flow_logic_case::class;
+        $case->config = Yaml::dump([
+            'cases' => [
+                'even numbers' => 'record.value % 2 == 0',
+                'odd numbers' => 'record.value % 2 == 1',
+            ],
+        ]);
+        $case->depends_on([$reader]);
+        $dataflow->add_step($case);
+        $steps[$case->id] = $case;
+
+        // Writer step for evens.
+        $even = new step();
+        $even->name = 'even (writer)';
+        $even->type = writer_stream::class;
+        $even->config = Yaml::dump([
+            'streamname' => 'even.csv',
+            'format' => 'csv',
+        ]);
+        $even->depends_on(['case' . step::DEPENDS_ON_POSITION_SPLITTER . '1']);
+        $dataflow->add_step($even);
+        $steps[$even->id] = $even;
+
+        // Writer step for odds.
+        $odd = new step();
+        $odd->name = 'odd (writer)';
+        $odd->type = writer_stream::class;
+        $odd->config = Yaml::dump([
+            'streamname' => 'odd.csv',
+            'format' => 'csv',
+        ]);
+        $odd->depends_on(['case' . step::DEPENDS_ON_POSITION_SPLITTER . '2']);
+        $dataflow->add_step($odd);
+        $steps[$odd->id] = $odd;
+
+        return [$dataflow, $steps];
+    }
+
+    /**
+     * Test case step is processed as expected
+     *
+     * @covers \tool_dataflows\local\step\flow_logic_case
+     */
+    public function test_path_is_resolved_as_expected() {
+        [$dataflow, $steps] = $this->create_dataflow();
+        $isdryrun = false;
+        $this->assertTrue($dataflow->validate_dataflow());
+
+        ob_start();
+        $engine = new engine($dataflow, $isdryrun);
+        $engine->execute();
+        ob_get_clean();
+
+        $oddcsv = $engine->resolve_path('odd.csv');
+        $oddcsv = file_get_contents($oddcsv);
+        $evencsv = $engine->resolve_path('even.csv');
+        $evencsv = file_get_contents($evencsv);
+
+        echo"<pre>";print_r([
+            'odd' => $oddcsv,
+            'even' => $evencsv,
+        ]);die;
+        // Check outputs (even.csv should contain only even numbers, odd.csv should only contain odd numbers)
+        // TODO: implement.
+        // Look inside the scratch dir's output folder.
+    }
+}

--- a/tests/tool_dataflows_flow_logic_case_test.php
+++ b/tests/tool_dataflows_flow_logic_case_test.php
@@ -22,6 +22,8 @@ use tool_dataflows\local\step\flow_logic_case;
 use tool_dataflows\local\step\writer_stream;
 use tool_dataflows\local\execution\array_in_type;
 
+defined('MOODLE_INTERNAL') || die();
+
 // This is needed. File will not be automatically included.
 require_once(__DIR__ . '/local/execution/array_in_type.php');
 

--- a/tests/tool_dataflows_secret_service_test.php
+++ b/tests/tool_dataflows_secret_service_test.php
@@ -128,7 +128,7 @@ class tool_dataflows_secret_service_test extends \advanced_testcase {
     }
 
     /**
-     * Description of what this does
+     * Tests generic redaction of values given a set of fields to redact
      *
      * @covers \tool_dataflows\local\service\secret_service::redact_fields
      */

--- a/tests/tool_dataflows_secret_service_test.php
+++ b/tests/tool_dataflows_secret_service_test.php
@@ -62,7 +62,7 @@ class tiny_connector_s3 extends connector_s3 {
      *
      * @return array
      */
-    protected static function form_define_fields(): array {
+    public static function form_define_fields(): array {
         return [
             'bucket'            => ['type' => PARAM_TEXT],
             'region'            => ['type' => PARAM_TEXT],

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022072501;
-$plugin->release = 2022072501;
+$plugin->version = 2022072502;
+$plugin->release = 2022072502;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022072500;
-$plugin->release = 2022072500;
+$plugin->version = 2022072501;
+$plugin->release = 2022072501;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
Basic support

Example dataflow: 
[even_and_odds_20220725_0518.yml.txt](https://github.com/catalyst/moodle-tool_dataflows/files/9178224/even_and_odds_20220725_0518.yml.txt)

Dataflow details view, with step dependency and the output position shown: 

![image](https://user-images.githubusercontent.com/9924643/180692386-de8c8d1b-e10c-4319-b9ed-2ef02c9a3a05.png)

![image](https://user-images.githubusercontent.com/9924643/180692373-dba21a07-a252-44ba-86e3-3d4400ec62b2.png)

![image](https://user-images.githubusercontent.com/9924643/180692426-01ae4c31-1bf8-4074-abba-3b473034b891.png)

DB example of it linking to the case step (position is based on option chosen):

![image](https://user-images.githubusercontent.com/9924643/179921151-e9491bc9-bb72-4b21-b7e4-95b34bfb3566.png)

Known issues:
- [x] No export/import support for it yet.
- [x] Dependency in step form not showing custom label (e.g. provided in case step)
- [x] Custom labels for output connections not displaying in dot graph yet
- [ ] No validation currently to ensure it doesn't break during runtime. 
- [ ] No validation for a case step expression set, but no link for it assigned yet.
- [x] Help text for cases can be improved, but not added yet.
- [x] Cannot see the numbered option as a selected option for it when you're updating a step 
- [x] Multiple flow groups might not work - it is assumed there is only one flow group. The logic for flow caps have been updated so this will likely cause issues if there are more than one flow group available.

Resolves #304 
Resolves #119
