### PR TITLE
docs: cleanup across the codebase

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -32,6 +32,7 @@ use tool_dataflows\local\step\flow_step;
 class dataflow extends persistent {
     use exportable;
 
+    /** The table name. */
     const TABLE = 'tool_dataflows';
 
     /** @var \stdClass of engine step states and timestamps */
@@ -45,6 +46,8 @@ class dataflow extends persistent {
 
     /**
      * When initialising the persistent, ensure some internal fields have been set up.
+     *
+     * @param  mixed ...$args
      */
     public function __construct(...$args) {
         parent::__construct(...$args);
@@ -52,12 +55,12 @@ class dataflow extends persistent {
     }
 
     /**
-     * Links the dataflow up to the relevant engine
+     * Links the engine up to this dataflow
      *
      * This is typically set when the engine is initialised, such that any
      * references made thereafter are directly connected to the engine's instance being used.
      *
-     * @param  dataflow
+     * @param  engine $engine
      */
     public function set_engine(engine $engine) {
         $this->engine = $engine;
@@ -102,7 +105,7 @@ class dataflow extends persistent {
     }
 
     /**
-     * Magic Getter
+     * Magic getter
      *
      * This allows any get_$name methods to be called if they exist, before any
      * property exist checks.
@@ -118,6 +121,13 @@ class dataflow extends persistent {
         return $this->get($name);
     }
 
+    /**
+     * Magic setter
+     *
+     * @param      string $name of the property
+     * @param      mixed $value of the property
+     * @return     $this
+     */
     public function __set($name, $value) {
         return $this->set($name, $value);
     }
@@ -573,8 +583,8 @@ class dataflow extends persistent {
      *
      * This will save the step if it has not been created in the database yet.
      *
-     * @param $step
-     * @return $this
+     * @param   step $step
+     * @return  $this
      */
     public function add_step(step $step) {
         $step->dataflowid = $this->id;
@@ -587,8 +597,8 @@ class dataflow extends persistent {
     /**
      * Removes a step from the flow
      *
-     * @param $step
-     * @return $this
+     * @param   step $step
+     * @return  $this
      */
     public function remove_step(step $step) {
         $step->delete();
@@ -667,8 +677,8 @@ class dataflow extends persistent {
     /**
      * Updates the value stored in the dataflow's config
      *
-     * @param  string name or path to name of field e.g. 'some.nested.fieldname'
-     * @param  mixed value
+     * @param  string $name or path to name of field e.g. 'some.nested.fieldname'
+     * @param  mixed $value
      */
     public function set_var($name, $value) {
         // Grabs the current config.

--- a/classes/dataflows_table.php
+++ b/classes/dataflows_table.php
@@ -26,6 +26,7 @@ namespace tool_dataflows;
  */
 class dataflows_table extends \table_sql {
 
+    /** Columns to display. */
     const COLUMNS = [
         'preview',
         'name',
@@ -35,6 +36,7 @@ class dataflows_table extends \table_sql {
         'details',
     ];
 
+    /** Columns that shouldn't be sorted. */
     const NOSORT_COLUMNS = [
         'preview',
         'actions',

--- a/classes/exportable.php
+++ b/classes/exportable.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Exportable trait
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
@@ -84,8 +93,7 @@ trait exportable {
     /**
      * Set the filename for the exported file.
      *
-     * @param   string $name The ID of the workflow.
-     * @param   int $now  The Unix timestamp to use in the file name.
+     * @param   int $now The Unix timestamp to use in the file name.
      * @return  string $filename
      */
     private function get_filename($now = null): string {

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -166,6 +166,9 @@ class engine {
         $this->create_flow_caps();
     }
 
+    /**
+     * Initialises the engine
+     */
     public function initialise() {
         try {
             $this->status_check(self::STATUS_NEW);
@@ -343,6 +346,8 @@ class engine {
 
     /**
      * PHP getter.
+     *
+     * @param  string $parameter
      */
     public function __get($parameter) {
         switch ($parameter) {
@@ -386,8 +391,8 @@ class engine {
      *
      * TODO: add instance support.
      *
-     * @param      string name of the field
-     * @param      mixed value
+     * @param      string $name of the field
+     * @param      mixed $value
      */
     public function set_dataflow_var($name, $value) {
         // Check if this field can be updated or not, e.g. if this was forced in config, it should not be updatable.
@@ -412,8 +417,8 @@ class engine {
      * config field. This however is stored via set_config and there is no
      * instance only support.
      *
-     * @param      string name of the field
-     * @param      mixed value
+     * @param      string $name of the field
+     * @param      mixed $value
      */
     public function set_global_var($name, $value) {
         // Grabs the current config.
@@ -494,7 +499,6 @@ class engine {
      * Resolves the full path name for the givne path. If the directory does nto exist, it will create it.
      *
      * @param  string $pathname
-     * @param  string $mode
      * @return false|resource
      */
     public function resolve_path(string $pathname) {
@@ -505,6 +509,7 @@ class engine {
         if (!file_exists($dir)) {
             mkdir($dir, $CFG->directorypermissions, true);
         }
+
         return $fullpath;
     }
 }

--- a/classes/local/execution/engine_step.php
+++ b/classes/local/execution/engine_step.php
@@ -31,8 +31,10 @@ abstract class engine_step {
 
     /** @var int Cannot go forward. Must cancel. */
     const PROCEED_STOP = 0;
+
     /** @var int Cannot go forward. Must wait. */
     const PROCEED_WAIT = 1;
+
     /** @var int Can go forward. Perform execution. */
     const PROCEED_GO = 2;
 
@@ -113,7 +115,7 @@ abstract class engine_step {
     /**
      * Exposes parameters that need to be accessed.
      *
-     * @param $parameter
+     * @param string $parameter
      * @return mixed
      * @throws \moodle_exception
      */
@@ -186,8 +188,8 @@ abstract class engine_step {
      * For example, set_var always goes to instance vars, set_config always
      * updates step's config.
      *
-     * @param      string name or path to name of field e.g. 'some.nested.fieldname'
-     * @param      mixed value
+     * @param  string $name or path to name of field e.g. 'some.nested.fieldname'
+     * @param  mixed $value
      */
     public function set_var($name, $value) {
         // Check if this is an available field to set in the step type.
@@ -219,8 +221,8 @@ abstract class engine_step {
      * This is a proxy to the engine's implementation.
      * TODO: add instance support.
      *
-     * @param  string name of the field
-     * @param  mixed value
+     * @param  string $name of the field
+     * @param  mixed $value
      */
     public function set_dataflow_var($name, $value) {
         $this->engine->set_dataflow_var($name, $value);
@@ -231,8 +233,8 @@ abstract class engine_step {
      *
      * This is a proxy to the engine's implementation.
      *
-     * @param  string name of the field
-     * @param  mixed value
+     * @param  string $name of the field
+     * @param  mixed $value
      */
     public function set_global_var($name, $value) {
         $this->engine->set_global_var($name, $value);

--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -29,15 +29,28 @@ use tool_dataflows\local\execution\flow_engine_step;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class dataflow_iterator implements iterator {
+
+    /** @var steptype $steptype */
     protected $steptype;
+
+    /** @var bool $finished */
     protected $finished = false;
+
+    /** @var mixed $input */
     protected $input;
+
+    /** @var flow_engine_step $step */
     protected $step;
+
+    /** @var mixed $value */
     protected $value = null;
 
+    /** @var int $iterationcount */
     protected $iterationcount = 0;
 
     /**
+     * Create an instance of this class.
+     *
      * @param flow_engine_step $step The step the iterator is for.
      * @param \Iterator|iterator|moodle_recordset $input An iterator of some sort
      */

--- a/classes/local/execution/iterators/iterator.php
+++ b/classes/local/execution/iterators/iterator.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Iterator interface for use within a dataflow structure.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows\local\execution\iterators;
 
 /**

--- a/classes/local/execution/logging_context.php
+++ b/classes/local/execution/logging_context.php
@@ -29,10 +29,10 @@ use tool_dataflows\local\step\flow_cap;
 class logging_context {
 
     /** @var engine $engine The engine. */
-    protected engine $engine = null;
+    protected $engine = null;
 
     /** @var engine_step $enginestep The engine step. */
-    protected engine_step $enginestep = null;
+    protected $enginestep = null;
 
     /**
      * Create an instance of this class.

--- a/classes/local/execution/logging_context.php
+++ b/classes/local/execution/logging_context.php
@@ -21,15 +21,25 @@ use tool_dataflows\local\step\flow_cap;
 /**
  * An environment for logging information about dataflow execution.
  *
- * @package
+ * @package   tool_dataflows
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class logging_context {
-    protected $engine = null;
-    protected $enginestep = null;
 
+    /** @var engine $engine The engine. */
+    protected engine $engine = null;
+
+    /** @var engine_step $enginestep The engine step. */
+    protected engine_step $enginestep = null;
+
+    /**
+     * Create an instance of this class.
+     *
+     * @param  engine_step|engine $object
+     * @throws \moodle_exception
+     */
     public function __construct($object) {
         if ($object instanceof engine_step) {
             $this->enginestep = $object;
@@ -41,6 +51,11 @@ class logging_context {
         }
     }
 
+    /**
+     * Handles logging
+     *
+     * @param   string $message
+     */
     public function log($message) {
         // Do not log anything for flowcaps as they are virtual.
         if (isset($this->enginestep) && $this->enginestep->steptype instanceof flow_cap) {

--- a/classes/local/formats/encoder_base.php
+++ b/classes/local/formats/encoder_base.php
@@ -25,8 +25,11 @@ namespace tool_dataflows\local\formats;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class encoder_base {
+
     /** @var bool Has data been added yet? */
     protected $sheetdatadded = false;
+
+    /** @var bool should the encoder prettify the output */
     protected $prettyprint = false;
 
     /**

--- a/classes/local/scheduler.php
+++ b/classes/local/scheduler.php
@@ -25,13 +25,16 @@ namespace tool_dataflows\local;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class scheduler {
+
+    /** The table name. */
     public const TABLE = 'tool_dataflows_schedule';
 
     /**
      * Get the scheduled times for a dataflow.
-     * @param int $dataflowid
-     * @return object|false
-     * @throws \dml_exception
+     *
+     * @param   int $stepid
+     * @return  object|false
+     * @throws  \dml_exception
      */
     public static function get_scheduled_times(int $stepid) {
         global $DB;
@@ -43,6 +46,7 @@ class scheduler {
      * Update an entry in the database for a dataflow.
      *
      * @param int $dataflowid
+     * @param int $stepid
      * @param int $newtime The new time for the next scheduled run.
      * @param int|null $oldtime The last time the dataflow ran. If null, the value will be unchanged.
      * @throws \dml_exception

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -267,7 +267,7 @@ abstract class base_step {
     /**
      * Sets up the form fields and inputs.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_setup(\MoodleQuickForm &$mform) {
         $this->form_add_custom_inputs($mform);
@@ -282,7 +282,7 @@ abstract class base_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         // Configuration - YAML format.
@@ -300,7 +300,7 @@ abstract class base_step {
      * This is mostly defined upfront and unlikely to change, and will show the following if not set:
      * "Did you remember to call setType() for __"
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_set_input_types(\MoodleQuickForm &$mform) {
         $fields = static::form_define_fields();
@@ -314,7 +314,7 @@ abstract class base_step {
     /**
      * Sets rules for each input field defined if supported
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_set_input_rules(\MoodleQuickForm &$mform) {
         $fields = static::form_define_fields();
@@ -364,8 +364,8 @@ abstract class base_step {
      * Converts the config data if required, such that it is set as expected
      * under a single key 'config'
      *
-     * @param      mixed &$data
-     * @return     mixed &$data
+     * @param      mixed $data
+     * @return     mixed $data
      */
     public function form_convert_fields(&$data) {
         // Construct configuration array based on standard format.
@@ -469,16 +469,12 @@ abstract class base_step {
 
     /**
      * Hook function that gets called when a step has been saved.
-     *
-     * @param step $stepdef
      */
     public function on_save() {
     }
 
     /**
      * Hook function that gets called when a step is deleted.
-     *
-     * @param step $stepdef
      */
     public function on_delete() {
     }

--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -15,7 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_dataflows\local\step;
-use tool_dataflows\local\execution\engine_step;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -59,7 +58,7 @@ class connector_curl extends connector_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         $jsonexample = [

--- a/classes/local/step/connector_debug_file_display.php
+++ b/classes/local/step/connector_debug_file_display.php
@@ -83,7 +83,7 @@ class connector_debug_file_display extends connector_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         // Stream name.

--- a/classes/local/step/connector_s3.php
+++ b/classes/local/step/connector_s3.php
@@ -58,7 +58,7 @@ class connector_s3 extends connector_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         $mform->addElement('text', 'config_bucket', get_string('connector_s3:bucket', 'tool_dataflows'));

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -51,6 +51,9 @@ abstract class flow_step extends base_step {
      *
      * Implementation can vary, this might be a transformer, resource, or
      * something else.
+     *
+     * @param   mixed $input
+     * @return  mixed $input
      */
     public function execute($input) {
         // Default is to do nothing.
@@ -72,7 +75,6 @@ abstract class flow_step extends base_step {
     /**
      * Get the iterator for the step, based on configurations.
      *
-     * @param flow_engine_step $step
      * @return iterator
      */
     public function get_iterator(): iterator {

--- a/classes/local/step/flow_transformer_filter.php
+++ b/classes/local/step/flow_transformer_filter.php
@@ -34,6 +34,9 @@ class flow_transformer_filter extends flow_transformer_step {
 
     /**
      * Apply the filter based on configuration
+     *
+     * @param   mixed $record
+     * @return  mixed $record
      */
     public function execute($record) {
         // TODO: implement.

--- a/classes/local/step/reader_json.php
+++ b/classes/local/step/reader_json.php
@@ -102,7 +102,8 @@ class reader_json extends reader_step {
     /**
      * Parses stream to json string.
      *
-     * @return string
+     * @param string $path
+     * @return string json
      * @throws \moodle_exception
      */
     protected function get_json_string(string $path): string {
@@ -179,7 +180,7 @@ class reader_json extends reader_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         // JSON array source.

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -54,12 +54,21 @@ class reader_sql extends reader_step {
         $query = $this->construct_query();
         return new class($this->enginestep, $query) extends dataflow_iterator {
 
+            /**
+             * Create an instance of this class.
+             *
+             * @param  flow_engine_step $step
+             * @param  string $query
+             */
             public function __construct(flow_engine_step $step, string $query) {
                 global $DB;
                 $input = $DB->get_recordset_sql($query);
                 parent::__construct($step, $input);
             }
 
+            /**
+             * Any custom handling for on_abort
+             */
             public function on_abort() {
                 $this->input->close();
             }
@@ -175,7 +184,7 @@ class reader_sql extends reader_step {
      * Returns a clarified error message if applicable.
      *
      * @param   string $message
-     * @param   ?string $sql replacement for the expression held by default.
+     * @param   string $sql replacement for the expression held by default.
      * @return  string clarified message if applicable
      */
     private function clarify_parser_error(string $message, ?string $sql = null): string {
@@ -244,8 +253,8 @@ class reader_sql extends reader_step {
     /**
      * Validate the configuration settings.
      *
-     * @param object $config
-     * @return true|\lang_string[] true if valid, an array of errors otherwise
+     * @param   object $config
+     * @return  true|\lang_string[] true if valid, an array of errors otherwise
      */
     public function validate_config($config) {
         $errors = [];
@@ -262,7 +271,7 @@ class reader_sql extends reader_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         // SQL.
@@ -287,6 +296,8 @@ class reader_sql extends reader_step {
      * Step callback handler
      *
      * Updates the counter value if a counterfield is supplied, but otherwise does nothing special to the data.
+     *
+     * @param  \stdClass $value
      */
     public function execute($value) {
         // Check the config for the counterfield.

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * SQL reader step
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows\local\step;
 
 use tool_dataflows\local\execution\flow_engine_step;
@@ -52,6 +61,7 @@ class reader_sql extends reader_step {
      */
     public function get_iterator(): iterator {
         $query = $this->construct_query();
+
         return new class($this->enginestep, $query) extends dataflow_iterator {
 
             /**

--- a/classes/local/step/reader_step.php
+++ b/classes/local/step/reader_step.php
@@ -18,7 +18,6 @@ namespace tool_dataflows\local\step;
 
 use tool_dataflows\local\execution\iterators\iterator;
 use tool_dataflows\local\execution\iterators\dataflow_iterator;
-use tool_dataflows\local\execution\flow_engine_step;
 
 /**
  * Base class for reader step types.

--- a/classes/local/step/trigger_cron.php
+++ b/classes/local/step/trigger_cron.php
@@ -69,7 +69,7 @@ class trigger_cron extends trigger_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         $mform->addElement('static', 'schedule_header', '', 'Schedule');

--- a/classes/local/step/writer_step.php
+++ b/classes/local/step/writer_step.php
@@ -45,8 +45,7 @@ abstract class writer_step extends flow_step {
     /**
      * Get the iterator for the step, based on configurations.
      *
-     * @param flow_engine_step $step
-     * @return iterator
+     * @return  data_iterator
      */
     public function get_iterator(): iterator {
         // Default is to simply map.

--- a/classes/local/step/writer_stream.php
+++ b/classes/local/step/writer_stream.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Stream writer step
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows\local\step;
 
 use tool_dataflows\local\execution\flow_engine_step;

--- a/classes/local/step/writer_stream.php
+++ b/classes/local/step/writer_stream.php
@@ -55,10 +55,10 @@ class writer_stream extends writer_step {
     /**
      * Returns the fully qualified classname for the class provided
      *
-     * @param      int
-     * @return     string empty string if the class is not found
+     * @param   string $classname
+     * @return  string empty string if the class is not found
      */
-    public static function resolve_encoder($classname): string {
+    public static function resolve_encoder(string $classname): string {
         if (class_exists($classname)) {
             return $classname;
         }
@@ -100,6 +100,13 @@ class writer_stream extends writer_step {
             /** @var object dataformat writer. */
             private $writer;
 
+            /**
+             * Create an instance of this class.
+             *
+             * @param  flow_engine_step $step
+             * @param  object $config
+             * @param  iterator $input
+             */
             public function __construct(flow_engine_step $step, $config, iterator $input) {
                 $this->streamname = $step->engine->resolve_path($config->streamname);
 
@@ -138,6 +145,9 @@ class writer_stream extends writer_step {
                 }
             }
 
+            /**
+             * Any custom handling for on_abort
+             */
             public function on_abort() {
                 if (fwrite($this->handle, $this->writer->close_output()) === false) {
                     $this->step->log(error_get_last()['message']);
@@ -211,7 +221,7 @@ class writer_stream extends writer_step {
      * It's recommended you prefix the additional config related fields to avoid
      * conflicts with any existing fields.
      *
-     * @param \MoodleQuickForm &$mform
+     * @param \MoodleQuickForm $mform
      */
     public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
         // Stream name.

--- a/classes/parser.php
+++ b/classes/parser.php
@@ -30,6 +30,11 @@ use Symfony\Component\Yaml\Yaml;
  */
 class parser {
 
+    /**
+     * Constructor for the parser
+     *
+     * Sets an expression language object and registers any supported methods.
+     */
     public function __construct() {
         $expressionlanguage = new ExpressionLanguage();
 
@@ -108,9 +113,9 @@ class parser {
     /**
      * Given an expression, and data. Evaluate and return the result.
      *
-     * @param      string $expression
-     * @param      array $variables containing anything relevant to the evaluation of the result
-     * @return     mixed
+     * @param   string $expression
+     * @param   array $variables containing anything relevant to the evaluation of the result
+     * @return  mixed
      */
     public function evaluate(string $expression, array $variables) {
         return $this->internal_evaluator($expression, $variables, function () {
@@ -121,19 +126,20 @@ class parser {
     /**
      * Evalulates the expression provided and on fail will throw an exception.
      *
-     * @param      string $expression
-     * @param      array $variables containing anything relevant to the evaluation of the result
-     * @return     mixed
+     * @param   string $expression
+     * @param   array $variables containing anything relevant to the evaluation of the result
+     * @param   callable $failcallback containing anything relevant to the evaluation of the result
+     * @return  mixed
      */
-    public function evaluate_or_fail(string $expression, array $variables, $failcallback = null) {
+    public function evaluate_or_fail(string $expression, array $variables, ?callable $failcallback = null) {
         return $this->internal_evaluator($expression, $variables, $failcallback);
     }
 
     /**
      * Returns whether or not the provided string contains an expression, and the matches
      *
-     * @param      string $expression
-     * @param      array $matches
+     * @param   string $expression the raw string being checked - might contain an expression
+     * @return  array $matches
      */
     public function has_expression(string $expression): array {
         preg_match_all('/(?<expressionwrapper>\${{(?<expression>.*)}})/mU', (string) $expression, $matches, PREG_SET_ORDER);
@@ -143,10 +149,10 @@ class parser {
     /**
      * Evalulates the expressions in the string provided.
      *
-     * @param      string $string
-     * @param      array $variables containing anything relevant to the evaluation of the result
-     * @param      ?callable $failcallback containing anything relevant to the evaluation of the result
-     * @return     mixed
+     * @param   string $string
+     * @param   array $variables containing anything relevant to the evaluation of the result
+     * @param   callable $failcallback containing anything relevant to the evaluation of the result
+     * @return  mixed
      */
     private function internal_evaluator(string $string, array $variables, ?callable $failcallback) {
         // TODO: lint expressions before storing them. https://symfony.com/blog/new-in-symfony-5-1-expressionlanguage-validator .

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -36,8 +36,13 @@ class provider implements \core_privacy\local\metadata\provider,
                           \core_privacy\local\request\plugin\provider,
                           \core_privacy\local\request\core_userlist_provider {
 
+    /**
+     * Returns meta data about this system.
+     *
+     * @param collection $collection — The initialised collection to add items to.
+     * @return collection — A listing of user data stored through this system.
+     */
     public static function get_metadata(collection $collection) : collection {
-
         $collection->add_database_table(
             'tool_dataflows',
             [

--- a/classes/run.php
+++ b/classes/run.php
@@ -27,6 +27,8 @@ use core\persistent;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class run extends persistent {
+
+    /** The table name. */
     const TABLE = 'tool_dataflows_runs';
 
     /**

--- a/classes/runs_table.php
+++ b/classes/runs_table.php
@@ -28,6 +28,7 @@ use tool_dataflows\local\execution\engine;
  */
 class runs_table extends \table_sql {
 
+    /** Columns to display. */
     const COLUMNS = [
         'name',
         'userid',
@@ -37,6 +38,7 @@ class runs_table extends \table_sql {
         'duration',
     ];
 
+    /** Columns that shouldn't be sorted. */
     const NOSORT_COLUMNS = ['actions'];
 
     /**

--- a/classes/step.php
+++ b/classes/step.php
@@ -34,6 +34,7 @@ use tool_dataflows\local\service\secret_service;
 class step extends persistent {
     use exportable;
 
+    /** The table name. */
     const TABLE = 'tool_dataflows_steps';
 
     /** @var array $dependson */

--- a/classes/step.php
+++ b/classes/step.php
@@ -48,6 +48,8 @@ class step extends persistent {
 
     /**
      * When initialising the persistent, ensure some internal fields have been set up.
+     *
+     * @param mixed ...$args
      */
     public function __construct(...$args) {
         parent::__construct(...$args);
@@ -106,7 +108,7 @@ class step extends persistent {
     /**
      * Magic getter - which allows the user to get values directly instead of via ->get('name')
      *
-     * @param      string name of the property to get
+     * @param      string $name of the property to get
      * @return     mixed
      */
     public function __get($name) {
@@ -120,8 +122,8 @@ class step extends persistent {
     /**
      * Magic setter - which allows the user to set values directly instead of via ->set('name', $value)
      *
-     * @param      string name of the property to update
-     * @param      mixed new value of the property
+     * @param      string $name of the property to update
+     * @param      mixed $value of the property
      * @return     $this
      */
     public function __set($name, $value) {
@@ -181,7 +183,7 @@ class step extends persistent {
      *
      * This would generally be initiliased by the engine.
      *
-     * @param   base_step
+     * @param   base_step $steptype
      */
     public function set_steptype(base_step $steptype) {
         $this->steptype = $steptype;
@@ -193,7 +195,7 @@ class step extends persistent {
      * This is typically set when the engine is initialised, such that any
      * references are directly connected to the engine's instance.
      *
-     * @param  dataflow
+     * @param  dataflow $dataflow
      */
     public function set_dataflow(dataflow $dataflow) {
         $this->dataflow = $dataflow;
@@ -268,7 +270,7 @@ class step extends persistent {
     /**
      * Validates the name field
      *
-     * @param      $string name provided
+     * @param      string $name provided
      * @return     true|lang_string will return a lang_string if there was an error
      */
     protected function validate_name($name) {
@@ -386,7 +388,7 @@ class step extends persistent {
      *
      * See dataflow->import for how this all strings together.
      *
-     * @param      array $yaml full dataflow configuration as a php array
+     * @param  array $stepdata full dataflow configuration as a php array
      */
     public function import($stepdata) {
         // Set the name of this step, the key will be used if a name is not provided.
@@ -742,8 +744,8 @@ class step extends persistent {
     /**
      * Updates the value stored in the step's config
      *
-     * @param      string name or path to name of field e.g. 'some.nested.fieldname'
-     * @param      mixed value
+     * @param  string $name or path to name of field e.g. 'some.nested.fieldname'
+     * @param  mixed $value
      */
     public function set_var($name, $value) {
         // Grabs the current config.
@@ -759,7 +761,7 @@ class step extends persistent {
     /**
      * Fills in output fields provided given an array of outputs
      *
-     * @param  mixed $value array of output fields to set. This is merged with any existing values.
+     * @param  mixed $attributes array of output fields to set. This is merged with any existing values.
      */
     public function set_output($attributes) {
         $this->outputs = $this->outputs ?? new \stdClass;

--- a/classes/steps_table.php
+++ b/classes/steps_table.php
@@ -17,10 +17,6 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\local\step\reader_step;
-use tool_dataflows\local\step\trigger_step;
-use tool_dataflows\local\step\connector_step;
-use tool_dataflows\local\step\flow_step;
 
 /**
  * Display a table of dataflow steps.

--- a/classes/steps_table.php
+++ b/classes/steps_table.php
@@ -28,6 +28,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class steps_table extends \table_sql {
 
+    /** Columns to display. */
     const COLUMNS = [
         'name',
         'alias',
@@ -38,6 +39,7 @@ class steps_table extends \table_sql {
         'details',
     ];
 
+    /** Columns that shouldn't be sorted. */
     const NOSORT_COLUMNS = [
         'actions',
         'dependson',

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -65,15 +65,14 @@ class visualiser {
      * with "dot" command and pipe the "dot_script" to it and pipe out the
      * generated image content.
      *
-     * @param string $dotscript the script for DOT to generate the image.
-     * @param $type supported image types: jpg, gif, png, svg, ps.
-     * @return binary|string content of the generated image on success, empty string on
-     *           failure.
+     * @param  string $dotscript the script for DOT to generate the image.
+     * @param  string $type supported image types: jpg, gif, png, svg, ps.
+     * @return binary|string content of the generated image on success, empty string on failure.
      *
      * @author     cjiang
      * @author     Kevin Pham <kevinpham@catalyst-au.net>
      */
-    public static function generate($dotscript, $type = 'svg') {
+    public static function generate(string $dotscript, ?string $type = 'svg') {
         global $CFG;
 
         $descriptorspec = [
@@ -115,6 +114,13 @@ class visualiser {
         throw new \Exception("failed to execute cmd \"$cmd\"");
     }
 
+    /**
+     * Prepares and builds out the dataflow table & page
+     *
+     * @param  dataflows_table $table
+     * @param  \moodle_url $url
+     * @param  string $pageheading
+     */
     public static function display_dataflows_table(dataflows_table $table, \moodle_url $url, string $pageheading) {
         global $PAGE;
 
@@ -168,6 +174,14 @@ class visualiser {
         echo $output->footer();
     }
 
+    /**
+     * Prepares and displays the dataflows details page
+     *
+     * @param  int $dataflowid
+     * @param  steps_table $table
+     * @param  \moodle_url $url
+     * @param  string $pageheading
+     */
     public static function display_dataflows_view_page(int $dataflowid, steps_table $table, \moodle_url $url, string $pageheading) {
         global $PAGE;
 

--- a/lib.php
+++ b/lib.php
@@ -30,9 +30,6 @@ require_once(dirname(__FILE__) . '/vendor/autoload.php');
 use tool_dataflows\local\formats\encoders;
 use tool_dataflows\local\step;
 
-function tool_dataflows_after_config() {
-}
-
 /**
  * Returns a list of step types available for this plugin.
  *

--- a/tests/application_trait.php
+++ b/tests/application_trait.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Helper unit test methods that are highly related to the application.
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows;
 
 /**
@@ -27,7 +36,16 @@ namespace tool_dataflows;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait application_trait {
+
     // @codingStandardsIgnoreStart
+
+    /**
+     * Asserts the record was found in the database
+     *
+     * @param   string $table
+     * @param   array $conditions
+     * @return  $this
+     */
     public function assertSeeInDatabase(string $table, array $conditions) {
         global $DB;
         $count = $DB->count_records($table, $conditions);
@@ -39,6 +57,13 @@ trait application_trait {
         return $this;
     }
 
+    /**
+     * Asserts the record was not found in the database
+     *
+     * @param   string $table
+     * @param   array $conditions
+     * @return  $this
+     */
     public function assertNotSeeInDatabase(string $table, array $conditions) {
         global $DB;
         $count = $DB->count_records($table, $conditions);
@@ -52,30 +77,54 @@ trait application_trait {
 
     // PHPUnit backwards compatible methods which handles the fallback to previous version calls.
 
-    public function compatible_assertStringContainsString(...$args): void {
+    /**
+     * Asserts whether the needle was found in the given haystack
+     *
+     * @param  string $needle
+     * @param  string $haystack
+     * @param  string $message
+     */
+    public function compatible_assertStringContainsString(string $needle, string $haystack, string $message = ''): void {
         if (method_exists($this, 'assertStringContainsString')) {
-            $this->assertStringContainsString(...$args);
+            $this->assertStringContainsString($needle, $haystack, $message);
         } else {
-            $this->assertContains(...$args);
+            $this->assertContains($needle, $haystack, $message);
         }
     }
 
-    public function compatible_assertMatchesRegularExpression(...$args): void {
+    /**
+     * Asserts that a string matches a given regular expression
+     *
+     * @param  string $pattern
+     * @param  string $string
+     * @param  string $message
+     */
+    public function compatible_assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void {
         if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression(...$args);
+            $this->assertMatchesRegularExpression($pattern, $string, $message);
         } else {
-            $this->assertRegExp(...$args);
+            $this->assertRegExp($pattern, $string, $message);
         }
     }
 
-    public function compatible_assertDoesNotMatchRegularExpression(...$args): void {
+    /**
+     * Asserts that a string does not match a given regular expression.
+     *
+     * @param  string $pattern
+     * @param  string $string
+     * @param  string $message
+     */
+    public function compatible_assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void {
         if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
-            $this->assertDoesNotMatchRegularExpression(...$args);
+            $this->assertDoesNotMatchRegularExpression($pattern, $string, $message);
         } else {
-            $this->assertNotRegExp(...$args);
+            $this->assertNotRegExp($pattern, $string, $message);
         }
     }
 
+    /**
+     * Asserts that an error was expected
+     */
     public function compatible_expectError(): void {
         if (method_exists($this, 'expectError')) {
             $this->expectError();

--- a/tests/local/execution/array_in_type.php
+++ b/tests/local/execution/array_in_type.php
@@ -23,14 +23,12 @@ use tool_dataflows\local\step\reader_step;
 
 /**
  * Test reader step type that supplies an array.
- * TODO: Until better classes have been defined, this is GEFN (Good Enough For Now).
  *
  * @package   tool_dataflows
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 class array_in_type extends reader_step {
 
     /** @var int[] number of input flows (min, max), zero for readers. */
@@ -39,10 +37,21 @@ class array_in_type extends reader_step {
     /** @var array The source. Place data here before use. */
     public static $source = [];
 
+    /**
+     * Get the iterator for the step, based on configurations.
+     *
+     * @return iterator
+     */
     public function get_iterator(): iterator {
         return new dataflow_iterator($this->enginestep, new \ArrayIterator(self::$source));
     }
 
+    /**
+     * Step callback handler
+     *
+     * @param   mixed $input
+     * @return  mixed $input
+     */
     public function execute($input) {
         return $input;
     }

--- a/tests/local/execution/array_out_type.php
+++ b/tests/local/execution/array_out_type.php
@@ -23,7 +23,6 @@ use tool_dataflows\local\step\writer_step;
 
 /**
  * Test writer step type that writes to an array.
- * TODO: Until better classes have been defined, this is GEFN (Good Enough For Now).
  *
  * @package   tool_dataflows
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
@@ -35,11 +34,24 @@ class array_out_type extends writer_step {
     /** @var array The output array that the dat is written into. Make sure it is empty before use. */
     public static $dest = [];
 
+    /**
+     * Get the iterator for the step, based on configurations.
+     *
+     * @return iterator
+     */
     public function get_iterator(): iterator {
         $input = current($this->enginestep->upstreams)->iterator;
         return new dataflow_iterator($this->enginestep, $input);
     }
 
+    /**
+     * Step callback handler
+     *
+     * Adds the input to the static $dest (destination)
+     *
+     * @param   mixed $input
+     * @return  mixed $input
+     */
     public function execute($input) {
         self::$dest[] = $input;
         return $input;

--- a/tests/local/execution/reader_sql_variable_setter.php
+++ b/tests/local/execution/reader_sql_variable_setter.php
@@ -48,6 +48,14 @@ class reader_sql_variable_setter extends reader_sql {
         );
     }
 
+    /**
+     * Step callback handler
+     *
+     * Sets variables at different scopes for fun.
+     *
+     * @param   mixed $input
+     * @return  mixed $input
+     */
     public function execute($input) {
         parent::execute($input);
         // Updates a dataflow scoped variable.

--- a/tests/local/execution/tool_dataflows_engine_test.php
+++ b/tests/local/execution/tool_dataflows_engine_test.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Unit tests covering the execution engine.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows\local\execution;
 
 use tool_dataflows\dataflow;
@@ -31,7 +40,12 @@ defined('MOODLE_INTERNAL') || die();
  */
 class test_engine extends engine {
 
-    /** Exposes all private fields for the purpose of testing them. */
+    /**
+     * Exposes all private fields for the purpose of testing them
+     *
+     * @param   mixed $p
+     * @return  mixed
+     */
     public function __get($p) {
         if (isset($this->$p)) {
             return $this->$p;

--- a/tests/tool_dataflows_secret_service_test.php
+++ b/tests/tool_dataflows_secret_service_test.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Unit tests for the secret service
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
@@ -33,6 +42,11 @@ require_once($CFG->libdir.'/tablelib.php');
 
 /**
  * Child class of connector_s3 with enforced secrets used for testing
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tiny_connector_s3 extends connector_s3 {
 
@@ -72,6 +86,7 @@ class tiny_connector_s3 extends connector_s3 {
 class tool_dataflows_secret_service_test extends \advanced_testcase {
     use application_trait;
 
+    /** A secret that shouldn't be known */
     const SECRET = 'OHNOYOUWERENTSUPPOSEDTOSEEME';
 
     /**

--- a/tests/tool_dataflows_stream_writer_test.php
+++ b/tests/tool_dataflows_stream_writer_test.php
@@ -48,7 +48,9 @@ class tool_dataflows_stream_writer_test extends \advanced_testcase {
      *
      * @covers \tool_dataflows\local\step\writer_step
      * @dataProvider data_provider
-     * @param $inputdata
+     * @param array $inputdata
+     * @param bool $isdryrun
+     * @param bool $prettyprint
      */
     public function test_writer_json($inputdata, $isdryrun, $prettyprint) {
         // Crate the dataflow.

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -50,6 +50,8 @@ class tool_dataflows_test extends \advanced_testcase {
     }
 
     /**
+     * Tests the ability to create an empty dataflow
+     *
      * @covers \tool_dataflows\dataflow
      */
     public function test_creating_empty_dataflow(): void {
@@ -74,6 +76,8 @@ class tool_dataflows_test extends \advanced_testcase {
     }
 
     /**
+     * Tests the dependant steps and generating a dot script
+     *
      * @covers \tool_dataflows\step
      * @covers \tool_dataflows\dataflow::get_dotscript
      */
@@ -116,6 +120,8 @@ class tool_dataflows_test extends \advanced_testcase {
     }
 
     /**
+     * Tests dataflow validation
+     *
      * @covers \tool_dataflows\step
      * @covers \tool_dataflows\dataflow::validate_dataflow
      */
@@ -174,6 +180,8 @@ class tool_dataflows_test extends \advanced_testcase {
     }
 
     /**
+     * Tests whether the is_dag graph function is giving the expected output
+     *
      * @covers \tool_dataflows\graph::is_dag
      */
     public function test_dag_check() {
@@ -267,6 +275,8 @@ class tool_dataflows_test extends \advanced_testcase {
     }
 
     /**
+     * Tests parsing expressions, with expressions set in the linked fixture
+     *
      * @covers \tool_dataflows\dataflow::config
      * @covers \tool_dataflows\step::config
      * @covers \tool_dataflows\parser::evaluate

--- a/tests/tool_dataflows_workflow_state_test.php
+++ b/tests/tool_dataflows_workflow_state_test.php
@@ -38,6 +38,9 @@ class tool_dataflows_workflow_state_test extends \advanced_testcase {
     }
 
     /**
+     * Testing the export function to ensure it does export expected state
+     * changes before and after execution
+     *
      * @covers \tool_dataflows\local\execution\engine::get_export_data
      * @covers \tool_dataflows\local\execution\engine::get_export
      */


### PR DESCRIPTION
Resolves #320 - OK to squash

The only remaining issues are:
```
/var/www/moodle/admin/tool/dataflows/classes/local/step/reader_sql.php
    Line 65: Class ( is not documented
--
  /var/www/moodle/admin/tool/dataflows/classes/local/step/writer_stream.php
    Line 104: Class ( is not documented
```
And this is because it doesn't really support anonymous classes with parameters properly.

I've created an issue here: https://github.com/moodlehq/moodle-local_moodlecheck/issues/91

Rough idea of the issues before this patch:
```
/var/www/moodle/admin/tool/dataflows/version.php
/var/www/moodle/admin/tool/dataflows/run.php
/var/www/moodle/admin/tool/dataflows/dataflow-action.php
/var/www/moodle/admin/tool/dataflows/visual.php
/var/www/moodle/admin/tool/dataflows/remove-step.php
/var/www/moodle/admin/tool/dataflows/view.php
/var/www/moodle/admin/tool/dataflows/edit.php
/var/www/moodle/admin/tool/dataflows/step.php
/var/www/moodle/admin/tool/dataflows/lang/en/tool_dataflows.php
/var/www/moodle/admin/tool/dataflows/export.php
/var/www/moodle/admin/tool/dataflows/lib.php
/var/www/moodle/admin/tool/dataflows/step-chooser.php
/var/www/moodle/admin/tool/dataflows/classes/run.php
/var/www/moodle/admin/tool/dataflows/classes/task/process_dataflows.php
/var/www/moodle/admin/tool/dataflows/classes/privacy/provider.php
/var/www/moodle/admin/tool/dataflows/classes/exportable.php
/var/www/moodle/admin/tool/dataflows/classes/step.php
    Line 40: Constant step::DEPENDS_ON_POSITION_SPLITTER is not documented
    Line 51: Phpdocs for function step::__construct has incomplete parameters list
    Line 111: Phpdocs for function step::__get has incomplete parameters list
    Line 125: Phpdocs for function step::__set has incomplete parameters list
    Line 186: Phpdocs for function step::set_steptype has incomplete parameters list
    Line 198: Phpdocs for function step::set_dataflow has incomplete parameters list
    Line 273: Phpdocs for function step::validate_name has incomplete parameters list
    Line 431: Phpdocs for function step::import has incomplete parameters list
    Line 787: Phpdocs for function step::set_var has incomplete parameters list
    Line 804: Phpdocs for function step::set_output has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/dataflows_table.php
    Line 29: Constant dataflows_table::COLUMNS is not documented
    Line 38: Constant dataflows_table::NOSORT_COLUMNS is not documented
/var/www/moodle/admin/tool/dataflows/classes/graph.php
/var/www/moodle/admin/tool/dataflows/classes/parser.php
    Line 33: Function parser::__construct is not documented
    Line 124: Phpdocs for function parser::evaluate_or_fail has incomplete parameters list
    Line 135: Phpdocs for function parser::has_expression has incomplete parameters list
    Line 146: Phpdocs for function parser::internal_evaluator has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/manager.php
/var/www/moodle/admin/tool/dataflows/classes/visualiser.php
    Line 118: Function visualiser::display_dataflows_table is not documented
    Line 171: Function visualiser::display_dataflows_view_page is not documented
    Line 68: Phpdocs for function visualiser::generate has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/renderer.php
/var/www/moodle/admin/tool/dataflows/classes/helper.php
/var/www/moodle/admin/tool/dataflows/classes/form/dataflow_form.php
/var/www/moodle/admin/tool/dataflows/classes/form/step_form.php
/var/www/moodle/admin/tool/dataflows/classes/runs_table.php
    Line 31: Constant runs_table::COLUMNS is not documented
    Line 40: Constant runs_table::NOSORT_COLUMNS is not documented
/var/www/moodle/admin/tool/dataflows/classes/local/scheduler.php
    Line 28: Constant scheduler::TABLE is not documented
    Line 32: Phpdocs for function scheduler::get_scheduled_times has incomplete parameters list
    Line 45: Phpdocs for function scheduler::set_scheduled_times has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/reader_json.php
    Line 102: Phpdocs for function reader_json::get_json_string has incomplete parameters list
    Line 182: Phpdocs for function reader_json::form_add_custom_inputs has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/reader_sql.php
    Line 55: Package is not specified for class (. It is also not specified in file-level phpdocs
    Line 17: File-level phpdocs block is not found
    Line 55: Class ( is not documented
    Line 57: Function reader_sql::__construct is not documented
    Line 63: Function reader_sql::on_abort is not documented
    Line 177: Phpdocs for function reader_sql::clarify_parser_error has incomplete parameters list
    Line 265: Phpdocs for function reader_sql::form_add_custom_inputs has incomplete parameters list
    Line 286: Phpdocs for function reader_sql::execute has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/writer_step.php
    Line 48: Phpdocs for function writer_step::get_iterator has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/connector_step.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/flow_cap.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/flow_transformer_filter.php
    Line 35: Phpdocs for function flow_transformer_filter::execute has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/flow_logic_step.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/trigger_cron.php
    Line 72: Phpdocs for function trigger_cron::form_add_custom_inputs has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/flow_logic_case.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/connector_curl.php
    Line 62: Phpdocs for function connector_curl::form_add_custom_inputs has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/trigger_step.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/connector_debug_file_display.php
    Line 86: Phpdocs for function connector_debug_file_display::form_add_custom_inputs has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/connector_debugging.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/base_step.php
    Line 270: Phpdocs for function base_step::form_setup has incomplete parameters list
    Line 285: Phpdocs for function base_step::form_add_custom_inputs has incomplete parameters list
    Line 303: Phpdocs for function base_step::form_set_input_types has incomplete parameters list
    Line 317: Phpdocs for function base_step::form_set_input_rules has incomplete parameters list
    Line 367: Phpdocs for function base_step::form_convert_fields has incomplete parameters list
    Line 473: Phpdocs for function base_step::on_save has incomplete parameters list
    Line 481: Phpdocs for function base_step::on_delete has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/flow_logic_join.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/reader_step.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/writer_stream.php
    Line 95: Package is not specified for class (. It is also not specified in file-level phpdocs
    Line 17: File-level phpdocs block is not found
    Line 95: Class ( is not documented
    Line 103: Function writer_stream::__construct is not documented
    Line 141: Function writer_stream::on_abort is not documented
    Line 58: Phpdocs for function writer_stream::resolve_encoder has incomplete parameters list
    Line 214: Phpdocs for function writer_stream::form_add_custom_inputs has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/connector_s3.php
    Line 61: Phpdocs for function connector_s3::form_add_custom_inputs has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/writer_debugging.php
/var/www/moodle/admin/tool/dataflows/classes/local/step/flow_step.php
    Line 49: Phpdocs for function flow_step::execute has incomplete parameters list
    Line 75: Phpdocs for function flow_step::get_iterator has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/step/flow_transformer_step.php
/var/www/moodle/admin/tool/dataflows/classes/local/formats/encoders/csv.php
/var/www/moodle/admin/tool/dataflows/classes/local/formats/encoders/json.php
/var/www/moodle/admin/tool/dataflows/classes/local/formats/encoder_base.php
    Line 30: Variable encoder_base::$prettyprint is not documented
/var/www/moodle/admin/tool/dataflows/classes/local/execution/engine_step.php
    Line 116: Phpdocs for function engine_step::__get has incomplete parameters list
    Line 189: Phpdocs for function engine_step::set_var has incomplete parameters list
    Line 222: Phpdocs for function engine_step::set_dataflow_var has incomplete parameters list
    Line 234: Phpdocs for function engine_step::set_global_var has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/execution/connector_engine_step.php
/var/www/moodle/admin/tool/dataflows/classes/local/execution/engine_flow_cap.php
/var/www/moodle/admin/tool/dataflows/classes/local/execution/flow_engine_step.php
/var/www/moodle/admin/tool/dataflows/classes/local/execution/logging_context.php
    Line 21: Package is not specified for class logging_context. It is also not specified in file-level phpdocs
    Line 24: Package  is not valid
    Line 33: Function logging_context::__construct is not documented
    Line 44: Function logging_context::log is not documented
    Line 30: Variable logging_context::$engine is not documented
    Line 31: Variable logging_context::$enginestep is not documented
/var/www/moodle/admin/tool/dataflows/classes/local/execution/engine.php
    Line 169: Function engine::initialise is not documented
    Line 344: Phpdocs for function engine::__get has incomplete parameters list
    Line 389: Phpdocs for function engine::set_dataflow_var has incomplete parameters list
    Line 415: Phpdocs for function engine::set_global_var has incomplete parameters list
    Line 496: Phpdocs for function engine::resolve_path has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/local/execution/iterators/iterator.php
    Line 29: Package is not specified for function is_finished. It is also not specified in file-level phpdocs
    Line 36: Package is not specified for function is_ready. It is also not specified in file-level phpdocs
    Line 43: Package is not specified for function abort. It is also not specified in file-level phpdocs
    Line 48: Package is not specified for function next. It is also not specified in file-level phpdocs
/var/www/moodle/admin/tool/dataflows/classes/local/execution/iterators/dataflow_iterator.php
    Line 32: Variable dataflow_iterator::$steptype is not documented
    Line 33: Variable dataflow_iterator::$finished is not documented
    Line 34: Variable dataflow_iterator::$input is not documented
    Line 35: Variable dataflow_iterator::$step is not documented
    Line 36: Variable dataflow_iterator::$value is not documented
    Line 38: Variable dataflow_iterator::$iterationcount is not documented
    Line 40: There is no description in phpdocs for function __construct
/var/www/moodle/admin/tool/dataflows/classes/local/service/secret_service.php
/var/www/moodle/admin/tool/dataflows/classes/steps_table.php
    Line 35: Constant steps_table::COLUMNS is not documented
    Line 45: Constant steps_table::NOSORT_COLUMNS is not documented
/var/www/moodle/admin/tool/dataflows/classes/dataflow.php
    Line 121: Function dataflow::__set is not documented
    Line 35: Constant dataflow::TABLE is not documented
    Line 46: Phpdocs for function dataflow::__construct has incomplete parameters list
    Line 60: Phpdocs for function dataflow::set_engine has incomplete parameters list
    Line 576: Phpdocs for function dataflow::add_step has incomplete parameters list
    Line 590: Phpdocs for function dataflow::remove_step has incomplete parameters list
    Line 670: Phpdocs for function dataflow::set_var has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/classes/import_form.php
/var/www/moodle/admin/tool/dataflows/import.php
/var/www/moodle/admin/tool/dataflows/view-run.php
/var/www/moodle/admin/tool/dataflows/settings.php
/var/www/moodle/admin/tool/dataflows/index.php
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_stream_writer_test.php
    Line 51: Phpdocs for function tool_dataflows_stream_writer_test::test_writer_json has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/tests/application_trait.php
    Line 31: Package is not specified for function assertSeeInDatabase. It is also not specified in file-level phpdocs
    Line 42: Package is not specified for function assertNotSeeInDatabase. It is also not specified in file-level phpdocs
    Line 55: Package is not specified for function compatible_assertStringContainsString. It is also not specified in file-level phpdocs
    Line 63: Package is not specified for function compatible_assertMatchesRegularExpression. It is also not specified in file-level phpdocs
    Line 71: Package is not specified for function compatible_assertDoesNotMatchRegularExpression. It is also not specified in file-level phpdocs
    Line 79: Package is not specified for function compatible_expectError. It is also not specified in file-level phpdocs
    Line 31: Function assertSeeInDatabase is not documented
    Line 42: Function assertNotSeeInDatabase is not documented
    Line 55: Function compatible_assertStringContainsString is not documented
    Line 63: Function compatible_assertMatchesRegularExpression is not documented
    Line 71: Function compatible_assertDoesNotMatchRegularExpression is not documented
    Line 79: Function compatible_expectError is not documented
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_scheduler_test.php
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_connector_debug_file_display_test.php
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_secret_service_test.php
    Line 34: Package is not specified for class tiny_connector_s3. It is also not specified in file-level phpdocs
    Line 17: File-level phpdocs block is not found
    Line 75: Constant tool_dataflows_secret_service_test::SECRET is not documented
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_connector_s3_test.php
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_workflow_state_test.php
    Line 40: There is no description in phpdocs for function test_exporting_state_before_and_after_execution
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_variables_test.php
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_sql_reader_test.php
/var/www/moodle/admin/tool/dataflows/tests/local/execution/array_in_type.php
    Line 34: Package is not specified for class array_in_type. It is also not specified in file-level phpdocs
    Line 34: Class array_in_type is not documented
    Line 42: Function array_in_type::get_iterator is not documented
    Line 46: Function array_in_type::execute is not documented
/var/www/moodle/admin/tool/dataflows/tests/local/execution/array_out_type.php
    Line 38: Function array_out_type::get_iterator is not documented
    Line 43: Function array_out_type::execute is not documented
    Line 24: No one-line description found in phpdocs for class array_out_type
/var/www/moodle/admin/tool/dataflows/tests/local/execution/reader_sql_variable_setter.php
    Line 51: Function reader_sql_variable_setter::execute is not documented
/var/www/moodle/admin/tool/dataflows/tests/local/execution/tool_dataflows_basic_execution_test.php
/var/www/moodle/admin/tool/dataflows/tests/local/execution/tool_dataflows_engine_test.php
    Line 17: File-level phpdocs block is not found
    Line 34: Phpdocs for function test_engine::__get has incomplete parameters list
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_test.php
    Line 52: There is no description in phpdocs for function test_creating_empty_dataflow
    Line 76: There is no description in phpdocs for function test_dependent_steps_and_dot_script
    Line 118: There is no description in phpdocs for function test_dataflow_validation
    Line 176: There is no description in phpdocs for function test_dag_check
    Line 269: There is no description in phpdocs for function test_expressions_parsing
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_curl_connector_test.php
/var/www/moodle/admin/tool/dataflows/tests/tool_dataflows_json_reader_test.php
/var/www/moodle/admin/tool/dataflows/runs.php
/var/www/moodle/admin/tool/dataflows/db/access.php
/var/www/moodle/admin/tool/dataflows/db/tasks.php
/var/www/moodle/admin/tool/dataflows/db/upgrade.php
```
