### PR TITLE
Issue #335: Fix importation of dataflows with bad path names.

### DIFF
--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -453,6 +453,15 @@ abstract class base_step {
     }
 
     /**
+     * Perform any extra validation that is required only for runs.
+
+     * @return true|array Will return true or an array of errors.
+     */
+    public function validate_for_run() {
+        return true;
+    }
+
+    /**
      * Generates an engine step for this type.
      *
      * This should be sufficient for most cases. Override this function if needed.

--- a/classes/local/step/writer_stream.php
+++ b/classes/local/step/writer_stream.php
@@ -179,11 +179,6 @@ class writer_stream extends writer_step {
         $errors = [];
         if (!isset($config->streamname)) {
             $errors['config_streamname'] = get_string('config_field_missing', 'tool_dataflows', 'streamname', true);
-        } else {
-            $error = helper::path_validate($config->streamname);
-            if ($error !== true) {
-                $errors['config_streamname'] = $error;
-            }
         }
         if (!isset($config->format)) {
             $errors['config_format'] = get_string('config_field_missing', 'tool_dataflows', 'format', true);
@@ -192,6 +187,22 @@ class writer_stream extends writer_step {
             if (!class_exists($format)) {
                 $errors['config_format'] = get_string('format_not_supported', 'tool_dataflows', $config->format, true);
             }
+        }
+
+        return empty($errors) ? true : $errors;
+    }
+
+    /**
+     * Perform any extra validation that is required only for runs.
+     *
+     * @return true|array Will return true or an array of errors.
+     */
+    public function validate_for_run() {
+        $config = $this->stepdef->config;
+
+        $error = helper::path_validate($config->streamname);
+        if ($error !== true) {
+            $errors['config_streamname'] = $error;
         }
 
         return empty($errors) ? true : $errors;

--- a/classes/step.php
+++ b/classes/step.php
@@ -573,6 +573,13 @@ class step extends persistent {
             $errors = array_merge($errors, $stepvalidation);
         }
 
+        $steptype = $this->get_steptype();
+        if ($steptype) {
+            $extravalidation = $steptype->validate_for_run();
+            if ($extravalidation !== true) {
+                $errors = array_merge($errors, $extravalidation);
+            }
+        }
         return empty($errors) ? true : $errors;
     }
 


### PR DESCRIPTION
Resolves #335 

Add validate_for_run() to base_step to perform extra validation for runs.
Move path check in writer_stream into validate_for_run().