### PR TITLE
fix: change order in which engine->abort logs the reason for aboting

### DIFF
--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -326,8 +326,8 @@ class engine {
         foreach ($this->enginesteps as $enginestep) {
             $enginestep->abort();
         }
-        $this->set_status(self::STATUS_ABORTED);
         $this->log('Aborted: ' . $message);
+        $this->set_status(self::STATUS_ABORTED);
 
         // TODO: We may want to make this the responsibility of the caller.
         if (!is_null($reason)) {


### PR DESCRIPTION
This was sometimes masking the underlying error message from being shown, showing instead some internal state validation message.

After patch, the abort reason is clearly shown:
```
2022 Jul 25, 18:23:47.434 Engine "I'm on the case!": Aborted: Table "tool_dataflows_versions" does not exist 
2022 Jul 25, 18:23:47.435 Engine "I'm on the case!": moodle_exception: Attempting to change the status of a dataflow engine after it has concluded. in /var/www/moodle/admin/tool/dataflows/classes/local/execution/engine.php:485
Stack trace:
#0 /var/www/moodle/admin/tool/dataflows/classes/local/execution/engine.php(362): tool_dataflows\local\execution\engine->set_status(8)
#1 /var/www/moodle/admin/tool/dataflows/classes/local/execution/engine.php(341): tool_dataflows\local\execution\engine->abort(Object(dml_exception))
#2 /var/www/moodle/admin/tool/dataflows/classes/local/execution/engine.php(291): tool_dataflows\local\execution\engine->finalise()
#3 /var/www/moodle/admin/tool/dataflows/run.php(109): tool_dataflows\local\execution\engine->execute()
#4 {main} 
```


Resolves #339
