### PR TITLE
fix: add lang strings that were missing in moodle 311 and below

### DIFF
--- a/classes/runs_table.php
+++ b/classes/runs_table.php
@@ -112,7 +112,7 @@ class runs_table extends \table_sql {
      * @return string
      */
     public function col_timestarted(\stdClass $record): string {
-        return userdate($record->timestarted, get_string('strftimedatetimeaccurate'));
+        return userdate($record->timestarted, get_string('strftimedatetimeaccurate', 'tool_dataflows'));
     }
 
     /**
@@ -122,7 +122,7 @@ class runs_table extends \table_sql {
      * @return string
      */
     public function col_timefinished(\stdClass $record): string {
-        return userdate($record->timefinished, get_string('strftimedatetimeaccurate'));
+        return userdate($record->timefinished, get_string('strftimedatetimeaccurate', 'tool_dataflows'));
     }
 
     /**

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -91,6 +91,7 @@ $string['field_duration'] = 'Duration';
 $string['startstate'] = 'Start state';
 $string['currentstate'] = 'Current state';
 $string['endstate'] = 'End state';
+$string['strftimedatetimeaccurate'] = '%d %B %Y, %I:%M:%S %p';
 
 // Step names.
 $string['step_name_connector_curl'] = 'Curl connector';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022072600;
-$plugin->release = 2022072600;
+$plugin->version = 2022072700;
+$plugin->release = 2022072700;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 

--- a/view-run.php
+++ b/view-run.php
@@ -95,8 +95,16 @@ $table->attributes['class'] = 'tool_dataflows table-run';
 $duration = number_format($run->timefinished - $run->timestarted, 4);
 $secsstr = get_string('secs');
 $data = [
-    'field_timestarted' => date_format_string($run->timestarted, get_string('strftimedatetimeaccurate'), $defaulttimezone),
-    'field_timefinished' => date_format_string($run->timefinished, get_string('strftimedatetimeaccurate'), $defaulttimezone),
+    'field_timestarted' => date_format_string(
+        $run->timestarted,
+        get_string('strftimedatetimeaccurate', 'tool_dataflows'),
+        $defaulttimezone
+    ),
+    'field_timefinished' => date_format_string(
+        $run->timefinished,
+        get_string('strftimedatetimeaccurate', 'tool_dataflows'),
+        $defaulttimezone
+    ),
     'field_duration' => $duration ? format_time($duration) : ("0 {$secsstr}"),
 ];
 $tabledata = [];


### PR DESCRIPTION
Lang string key and value copied as-is from newer moodle's lang/en/langconfig.php

Resolves #355
