### PR TITLE
fix: case matching order to evaluate cases in order

### DIFF
--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -339,7 +339,7 @@ $string['check:dataflows_run_status'] = 'Run {$a->name} - {$a->state}';
 
 // Flow logic: Case.
 $string['flow_logic_case:cases'] = 'Cases';
-$string['flow_logic_case:cases_help'] = 'Each line represents a case, and each case has a label for display, and an expression separated by a colon "<code>:</code>", used to determine whether the linked step will consume the data that flows or not. If no label is present, it will instead the line number for that connection.';
+$string['flow_logic_case:cases_help'] = 'Each line represents a case, and each case has a label for display, and an expression separated by a colon "<code>:</code>", used to determine whether the linked step will consume the data that flows or not. If no label is present, it will instead use the line number for that connection. You can use <code>default: 1</code> as the last entry to ensure it always matches on at least one step - should all other expressions fail. Otherwise, if all expressions fail to match, the record will not flow through and would be skipped.';
 $string['flow_logic_case:casenotfound'] = 'The output position of #{$a} did not match any existing case';
 
 // Wait connector.


### PR DESCRIPTION
Previously it would push the record downstream if an out of order step's expression was truthy.

Also adjusted the help text to make this a bit clearer in how it is expected to work

Resolves #347

Example workflow:
[one_direction_20220729_0119.yml.txt](https://github.com/catalyst/moodle-tool_dataflows/files/9215239/one_direction_20220729_0119.yml.txt)
This should flow in one downstream, and store all results in one file. The other file should be empty, even though both expressions are truthy

Lang string changes:

![image](https://user-images.githubusercontent.com/9924643/181662791-50d47f91-8778-44fe-88f0-ab606d4bda72.png)

No placeholder shown:

![image](https://user-images.githubusercontent.com/9924643/181662807-66b5dc18-06a8-47dd-add9-e0d2fb2ae190.png)

