### PR TITLE
Issue #374: Fix Permitted directories bug

### DIFF
--- a/classes/admin/admin_setting_permitted_directories.php
+++ b/classes/admin/admin_setting_permitted_directories.php
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_dataflows;
+namespace tool_dataflows\admin;
+
+use \tool_dataflows\helper;
 
 /**
  * A custom setting for the permitted directories that a dataflow can interact with.
@@ -38,14 +40,25 @@ class admin_setting_permitted_directories extends \admin_setting_configtextarea 
     public function validate($data) {
         global $CFG;
 
-        if (empty($data)) {
+        // Strip /*..*/ comments.
+        $data = preg_replace('!/\*.*?\*/!s', '', $data);
+
+        if (empty(trim($data))) {
             return true;
         }
 
-        $lines = explode("\n", trim($data));
+        $lines = explode(PHP_EOL, $data);
 
         $errors = [];
         foreach ($lines as $line) {
+
+            // Strip # comments, and trim.
+            $line = trim(preg_replace('/#.*$/', '', $line));
+
+            // Ignore empty lines.
+            if ($line == '') {
+                continue;
+            }
 
             // Substitute dataroot placeholder, if found.
             if (substr($line, 0, strlen(helper::DATAROOT_PLACEHOLDER)) === helper::DATAROOT_PLACEHOLDER) {

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -37,7 +37,7 @@ $string['enabled_help'] = '';
 $string['permitted_dirs'] = 'Permitted directories';
 $string['permitted_dirs_desc'] = "List directories here to allow them to be read from/written to by dataflow steps.
     One directory per line. Each directory must be an absolute path. You can use the place holder '{\$a}' for the
-    site's data root directory.\n
+    site's data root directory. You can also include comments using /* and */.\n
     Examples.
     /tmp
     /home/me/mydata

--- a/settings.php
+++ b/settings.php
@@ -25,6 +25,7 @@
  */
 
 use \tool_dataflows\helper;
+use \tool_dataflows\admin\admin_setting_permitted_directories;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -46,7 +47,7 @@ if ($hassiteconfig) {
             '0'
         ));
 
-        $settings->add(new \tool_dataflows\admin_setting_permitted_directories(
+        $settings->add(new admin_setting_permitted_directories(
             'tool_dataflows/permitted_dirs',
             get_string('permitted_dirs', 'tool_dataflows'),
             get_string('permitted_dirs_desc', 'tool_dataflows', helper::DATAROOT_PLACEHOLDER),

--- a/tests/tool_dataflows_helper_test.php
+++ b/tests/tool_dataflows_helper_test.php
@@ -37,15 +37,42 @@ class tool_dataflows_helper_test extends \advanced_testcase {
     /**
      * Tests the get_permitted_dirs() function.
      *
+     * @dataProvider dir_provider
      * @covers \tool_dataflows\helper::get_permitted_dirs
+     * @param string $data
+     * @param array $expected
      */
-    public function test_get_permitted_dirs() {
-        global $CFG;
-
-        set_config('permitted_dirs', "/home/me/tmp\n[dataroot]/tmp", 'tool_dataflows');
+    public function test_get_permitted_dirs(string $data, array $expected) {
+        set_config('permitted_dirs', $data, 'tool_dataflows');
         $dirs = helper::get_permitted_dirs();
-        $this->assertCount(2, $dirs);
-        $this->assertEquals('/home/me/tmp', $dirs[0]);
-        $this->assertEquals($CFG->dataroot . '/tmp', $dirs[1]);
+        $this->assertEquals($expected, $dirs);
+    }
+
+    /**
+     * Provides raw permitted directories config values.
+     *
+     * @return array[]
+     */
+    public function dir_provider(): array {
+        global $CFG;
+        return [
+            ['', []],
+            [
+                '/home/me/tmp ' . PHP_EOL . '  ' . PHP_EOL . '[dataroot]/tmp ',
+                ['/home/me/tmp', $CFG->dataroot . '/tmp']
+            ],
+            [
+                '/* A comment' . PHP_EOL . ' over two lines */' . PHP_EOL . '/tmp' . PHP_EOL . '/var',
+                ['/tmp', '/var']
+            ],
+            [
+                '# comment' . PHP_EOL . '/var/tmp   # more comments.',
+                ['/var/tmp']
+            ],
+            [
+                '/var/[dataroot]/tmp',
+                ['/var/[dataroot]/tmp']
+            ],
+        ];
     }
 }

--- a/tests/tool_dataflows_json_reader_test.php
+++ b/tests/tool_dataflows_json_reader_test.php
@@ -43,6 +43,8 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
         parent::setUp();
         $this->resetAfterTest();
 
+        set_config('permitted_dirs', '/tmp', 'tool_dataflows');
+
         $this->dataflow = $this->create_dataflow();
         $this->set_initial_test_data();
     }

--- a/tests/tool_dataflows_permitted_dir_test.php
+++ b/tests/tool_dataflows_permitted_dir_test.php
@@ -1,0 +1,101 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+use \tool_dataflows\admin\admin_setting_permitted_directories;
+
+defined('MOODLE_INTERNAL') || die();
+
+// Needed because CI complains.
+global $CFG;
+require_once($CFG->libdir.'/adminlib.php');
+
+/**
+ * Tests the admin_setting_permitted_directories class.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_permitted_dir_test extends \advanced_testcase {
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Test validate with valid values.
+     *
+     * @dataProvider valid_data_provider
+     * @covers \tool_dataflows\admin_setting_permitted_directories::validate
+     * @param string $data
+     */
+    public function test_validate_valid(string $data) {
+        $setting = new admin_setting_permitted_directories('tool_dataflows/permitted_dirs', '', '', '');
+        $this->assertTrue($setting->validate($data));
+    }
+
+    /**
+     * Provides valid data.
+     *
+     * @return \string[][]
+     */
+    public function valid_data_provider(): array {
+        return [
+            [''],
+            ['/* A comment */'],
+            ['/tmp' . PHP_EOL . PHP_EOL . '/var'],
+            ['/tmp'],
+            ['/tmp ' . PHP_EOL . '  ' . PHP_EOL . '[dataroot]/var ' . PHP_EOL],
+            ['file:///tmp'],
+            ['# a comment'],
+            ['/var/tmp  # another comment'],
+        ];
+    }
+
+    /**
+     * Test validate with invalid values.
+     *
+     * @dataProvider invalid_data_provider
+     * @covers \tool_dataflows\admin_setting_permitted_directories::validate
+     * @param string $data
+     * @param string $error
+     */
+    public function test_validate_invalid(string $data, string $error) {
+        $setting = new admin_setting_permitted_directories('tool_dataflows/permitted_dirs', '', '', '');
+        $result = $setting->validate($data);
+        $this->assertEquals(get_string($error, 'tool_dataflows', $data), $result);
+    }
+
+    /**
+     * Provides invalid data, along with the error lang index.
+     *
+     * @return \string[][]
+     */
+    public function invalid_data_provider(): array {
+        return [
+            ['/tmp/* A comment', 'path_invalid'],
+            ['http://tmp', 'path_invalid'],
+            ['tmp', 'path_not_absolute'],
+        ];
+    }
+}

--- a/tests/tool_dataflows_stream_writer_test.php
+++ b/tests/tool_dataflows_stream_writer_test.php
@@ -41,6 +41,8 @@ class tool_dataflows_stream_writer_test extends \advanced_testcase {
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
+
+        set_config('permitted_dirs', '/tmp', 'tool_dataflows');
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022072700;
-$plugin->release = 2022072700;
+$plugin->version = 2022072900;
+$plugin->release = 2022072900;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
Resolves #374 

Add checks to get_permitted_dirs() to exclude empty values.
Fix unit tests.
Add more unit tests
Remove empty lines before saving value.
Moved admin_setting_permitted_directories to classes/admin.
