### PR TITLE
fix: value passed to get_output_label should not be null

### DIFF
--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -157,7 +157,7 @@ class step_form extends \core\form\persistent {
                 // Check if the current step is a dependant, and if so, INCLUDE the option (and ensure it is selected).
                 $currentstepid = $persistent->id;
                 $selectedposition = null;
-                if (!empty($currentstepid) && isset($dependants[$currentstepid])) {
+                if (!empty($currentstepid) && isset($dependants[$currentstepid]->position)) {
                     $selectedposition = $dependants[$currentstepid]->position;
                     $availablepositions[] = $selectedposition;
                     sort($availablepositions);


### PR DESCRIPTION
Co-Authored-By: null <marcghaly@users.noreply.github.com>

Resolves #411 

Issue was caused by the position calling get_output_label, but the position value was null. This shouldn't be possible normally and is fixed in another PR #419, but this should cover both cases gracefully regardless.