### PR TITLE
Fix: nullify literal expression when not assessed - be able to evalut…

### DIFF
--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -124,6 +124,16 @@ abstract class base_step {
             $parser = new parser;
             $allvariables = array_merge($this->stepdef->variables, $this->variables);
             $outputs = $parser->evaluate_recursive($config->outputs, $allvariables);
+            // Check that outputs have been assessed.
+            foreach ($outputs as $key => $output) {
+                // If type is an object it means it has been assessed.
+                if (!is_object($output)) {
+                    [$hasexpression] = $parser->has_expression($output);
+                    if ($hasexpression) {
+                        $outputs->$key = null;
+                    }
+                }
+            }
             $this->stepdef->set_output($outputs);
         }
     }

--- a/classes/local/step/flow_logic_case.php
+++ b/classes/local/step/flow_logic_case.php
@@ -192,6 +192,7 @@ class flow_logic_case extends flow_logic_step {
                     $this->passed = false;
                 }
                 $value = $this->input->current();
+                $steps = $caller->step->engine->get_variables()['steps'];
 
                 $casenumber = $this->stepcasemap[$caller->step->id];
                 $position = $casenumber + 1;
@@ -209,7 +210,7 @@ class flow_logic_case extends flow_logic_step {
                 $parser = new parser;
                 $casefailures = 0;
                 foreach ($this->cases as $caseindex => $case) {
-                    $result = (bool) $parser->evaluate_or_fail('${{ ' . $case . ' }}', ['record' => $value]);
+                    $result = (bool) $parser->evaluate_or_fail('${{' . $case . '}}', ['record' => $value, 'steps' => $steps]);
 
                     // If there was a passing expression, break the loop.
                     if ($result === true) {


### PR DESCRIPTION
Hi,

This issue resolves issue #416, it allows evaluating mapped outputs in case comparison as such

![Screenshot from 2022-08-04 16-48-14](https://user-images.githubusercontent.com/76186988/182949852-df0a6034-cf3e-4a69-a38f-fa4d8e41a03e.png)


Regards,

Marc