### PR TITLE
fix: show all output options for any selector when editing a step

### DIFF
--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -149,10 +149,7 @@ class step_form extends \core\form\persistent {
                 // are linked. It should show 6 possible options for the next
                 // step that can get linked.
                 $outputlabelscount = count($step->steptype->get_output_labels());
-                $allpositions = range(1, min($max, $outputlabelscount));
-
-                $takenpositions = array_column($dependants, 'position');
-                $availablepositions = array_diff($allpositions, $takenpositions);
+                $availablepositions = range(1, min($max, $outputlabelscount));
 
                 // Check if the current step is a dependant, and if so, INCLUDE the option (and ensure it is selected).
                 $currentstepid = $persistent->id;


### PR DESCRIPTION
Previously it would not show any 'positions' that have already been taken. Now it will show them all (filtered down to options set if labels are set)

![image](https://user-images.githubusercontent.com/9924643/183008325-9ae6096d-e4be-41ad-b1f4-aa0e2925997c.png)

Resolves #427 