### PR TITLE
422 i give you permission to

### DIFF
--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -372,7 +372,7 @@ class step_form extends \core\form\persistent {
                 $position = strrpos($classname, '\\');
                 $basename = substr($classname, $position + 1);
                 if ($position !== false) {
-                    $data->name = str_replace('_step', '', $basename); // So curl_step becomes curl.
+                    $data->name = $basename;
                 }
             }
         }

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -87,6 +87,10 @@ class step_form extends \core\form\persistent {
         );
         $select->setMultiple(true);
 
+        // Is like a connector step? Does not operate within a flow group.
+        $mform->addElement('advcheckbox', 'connector', 'Behave like a connector step? (WIP)', false);
+        $mform->setType('connector', PARAM_BOOL);
+
         // List all the available fields available for configuration, in dot syntax.
         $variables = $this->get_available_references();
         $mform->addElement('html', $this->prepare_available_fields($variables));
@@ -362,12 +366,14 @@ class step_form extends \core\form\persistent {
             $steptype = new $type();
             $data = $steptype->form_get_default_data($data);
 
-            // Automatically fill in the name with something hopefully sane.
-            $classname = $type;
-            $position = strrpos($classname, '\\');
-            $basename = substr($classname, $position + 1);
-            if ($position !== false) {
-                $data->name = str_replace('_step', '', $basename); // So curl_step becomes curl.
+            // Automatically fill in the name with something hopefully sane for new steps.
+            if (empty($data->id)) {
+                $classname = $type;
+                $position = strrpos($classname, '\\');
+                $basename = substr($classname, $position + 1);
+                if ($position !== false) {
+                    $data->name = str_replace('_step', '', $basename); // So curl_step becomes curl.
+                }
             }
         }
 

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -361,6 +361,14 @@ class step_form extends \core\form\persistent {
         if (!empty($type) && class_exists($type)) {
             $steptype = new $type();
             $data = $steptype->form_get_default_data($data);
+
+            // Automatically fill in the name with something hopefully sane.
+            $classname = $type;
+            $position = strrpos($classname, '\\');
+            $basename = substr($classname, $position + 1);
+            if ($position !== false) {
+                $data->name = str_replace('_step', '', $basename); // So curl_step becomes curl.
+            }
         }
 
         return $data;

--- a/classes/local/execution/connector_engine_step.php
+++ b/classes/local/execution/connector_engine_step.php
@@ -44,7 +44,7 @@ class connector_engine_step extends engine_step {
         switch ($this->proceed_status()) {
             case self::PROCEED_GO:
                 try {
-                    $result = $this->steptype->execute($this);
+                    $result = $this->steptype->execute(new \stdClass);
                     $this->steptype->prepare_outputs();
                     if ($result !== false) {
                         $this->set_status(engine::STATUS_FINISHED);

--- a/classes/local/execution/connector_engine_step.php
+++ b/classes/local/execution/connector_engine_step.php
@@ -46,7 +46,7 @@ class connector_engine_step extends engine_step {
                 try {
                     $result = $this->steptype->execute($this);
                     $this->steptype->prepare_outputs();
-                    if ($result === true) {
+                    if ($result !== false) {
                         $this->set_status(engine::STATUS_FINISHED);
                     } else {
                         $this->set_status(engine::STATUS_CANCELLED);

--- a/classes/local/execution/engine_step.php
+++ b/classes/local/execution/engine_step.php
@@ -293,4 +293,26 @@ abstract class engine_step {
                 break;
         }
     }
+
+    /**
+     * Returns an array with all the variables available, with the context of the step
+     *
+     * @return  array
+     */
+    public function get_variables(): array {
+        // Config values are directly referenceable, step values go through
+        // step.fieldname, everything else is available through expressions,
+        // such as 'dataflow.id' and 'steps.mystep.name' for example.
+        $variables = $this->engine->get_variables();
+        $step = $variables['steps']->{$this->stepdef->alias};
+
+        // Pull out the config.
+        $config = $step->config;
+
+        return array_merge(
+            $variables,
+            ['step' => $step],
+            (array) $config,
+        );
+    }
 }

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -477,7 +477,7 @@ abstract class base_step {
      *
      * @return engine_step
      */
-    final public function get_engine_step(): engine_step {
+    final public function get_engine_step(): ?engine_step {
         return $this->enginestep;
     }
 

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -18,8 +18,10 @@ namespace tool_dataflows\local\step;
 
 use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\helper;
+use tool_dataflows\local\execution\connector_engine_step;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\engine_step;
+use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\parser;
 use tool_dataflows\step;
 
@@ -482,12 +484,21 @@ abstract class base_step {
     }
 
     /**
-     * Generate the engine step for the step type.
+     * Generates an engine step for this type.
+     *
+     * This should be sufficient for most cases. Override this function if needed.
      *
      * @param engine $engine
      * @return engine_step
      */
-    abstract protected function generate_engine_step(engine $engine): engine_step;
+    protected function generate_engine_step(engine $engine): engine_step {
+        // Determine if it should return a flow (iterator based) or connector (no iterator) engine step.
+        if ($this->is_flow()) {
+            return new flow_engine_step($engine, $this->stepdef, $this);
+        }
+
+        return new connector_engine_step($engine, $this->stepdef, $this);
+    }
 
     /**
      * Returns the group (string) this step type is categorised under.

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -627,7 +627,7 @@ abstract class base_step {
      * @return  \stdClass configuration object
      */
     protected function get_config() {
-        return $this->enginestep->stepdef->config;
+        return $this->enginestep->stepdef->config ?? $this->stepdef->config;
     }
 
     /**

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -607,4 +607,37 @@ abstract class base_step {
         $label = $labels[$position] ?? (string) $position;
         return $label;
     }
+
+    /**
+     * Get the step's (definition) current config.
+     *
+     * Helper method to reduce the complexity when authoring step types.
+     *
+     * @return  \stdClass configuration object
+     */
+    protected function get_config() {
+        return $this->enginestep->stepdef->config;
+    }
+
+    /**
+     * Returns whether the engine's run is dry
+     *
+     * Helper method to reduce the complexity when authoring step types.
+     *
+     * @return  bool mode is in dry run or not
+     */
+    protected function is_dry_run() {
+        return $this->enginestep->engine->isdryrun;
+    }
+
+    /**
+     * Emits a log message
+     *
+     * Helper method to reduce the complexity when authoring step types.
+     *
+     * @param string $message
+     */
+    protected function log($message) {
+        $this->enginestep->log($message);
+    }
 }

--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -44,7 +44,7 @@ class connector_curl extends connector_step {
      * @link https://en.wikipedia.org/wiki/Side_effect_(computer_science)
      */
     public function has_side_effect(): bool {
-        if (isset($this->stepdef)) {
+        if (!empty($this->stepdef->id)) {
             $config = $this->stepdef->config;
 
             // Destination is outside of scratch directory.

--- a/classes/local/step/connector_s3.php
+++ b/classes/local/step/connector_s3.php
@@ -42,7 +42,7 @@ class connector_s3 extends connector_step {
      * @link https://en.wikipedia.org/wiki/Side_effect_(computer_science)
      */
     public function has_side_effect(): bool {
-        if (isset($this->stepdef)) {
+        if (!empty($this->stepdef->id)) {
             $config = $this->stepdef->config;
             return !helper::path_is_relative($config->target);
         }

--- a/classes/local/step/connector_step.php
+++ b/classes/local/step/connector_step.php
@@ -58,18 +58,6 @@ abstract class connector_step extends base_step {
     }
 
     /**
-     * Generates an engine step for this type.
-     *
-     * This should be sufficient for most cases. Override this function if needed.
-     *
-     * @param engine $engine
-     * @return engine_step
-     */
-    protected function generate_engine_step(engine $engine): engine_step {
-        return new connector_engine_step($engine, $this->stepdef, $this);
-    }
-
-    /**
      * Returns an array with styles used to draw the dot graph
      *
      * @return  array containing the styles

--- a/classes/local/step/curl.php
+++ b/classes/local/step/curl.php
@@ -43,7 +43,8 @@ class curl extends flow_step {
      * @return  bool whether or not this step has a side effect
      */
     public function has_side_effect(): bool {
-        if (!empty($this->stepdef->id)) {
+        $id = $this->stepdef->id;
+        if ($id) {
             $config = $this->stepdef->config;
 
             // Destination is outside of scratch directory.

--- a/classes/local/step/curl.php
+++ b/classes/local/step/curl.php
@@ -28,7 +28,7 @@ use tool_dataflows\helper;
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class curl_step extends flow_step {
+class curl extends flow_step {
 
     /** @var int time after which curl request is aborted */
     protected $timeout = 60;

--- a/classes/local/step/curl_step.php
+++ b/classes/local/step/curl_step.php
@@ -129,7 +129,7 @@ class curl_step extends flow_step {
             'patch'  => 'PATCH',
             'put'    => 'PUT',
         ]);
-        $urlarray[] =& $mform->createElement('text', 'config_curl', '');
+        $urlarray[] =& $mform->createElement('text', 'config_curl', '', ['style' => 'width: 36rem']);
 
         $mform->addGroup($urlarray, 'buttonar', get_string('connector_curl:curl', 'tool_dataflows'), [' '], false);
         $mform->addRule('buttonar', get_string('required'), 'required', null, 'server');
@@ -199,14 +199,14 @@ class curl_step extends flow_step {
      */
     public function execute($input) {
         // Get variables.
-        $config = $this->enginestep->stepdef->config;
-        $isdryrun = $this->enginestep->engine->isdryrun;
+        $config = $this->get_config();
+        $isdryrun = $this->is_dry_run();
+
+        $url = $config->curl;
         $method = $config->method;
 
-        $this->enginestep->log($config->curl);
-
-        $dbgcommand = 'curl -X ' .  strtoupper($method) . ' ' . $config->curl;
-        $result = null;
+        $this->log($url);
+        $dbgcommand = 'curl -X ' .  strtoupper($method) . ' ' . $url;
 
         if (!empty($config->timeout)) {
             $this->timeout = (int) $config->timeout;
@@ -255,8 +255,9 @@ class curl_step extends flow_step {
         }
 
         // Perform call.
+        $result = null;
         if (!$isdryrun) {
-            $result = $curl->$method($config->curl, [], $options);
+            $result = $curl->$method($url, [], $options);
         }
 
         if (!empty($file)) {
@@ -276,7 +277,7 @@ class curl_step extends flow_step {
         }
 
         // Log the raw curl command.
-        $this->enginestep->log($dbgcommand);
+        $this->log($dbgcommand);
         $this->set_variables('dbgcommand', $dbgcommand);
 
         if (!$isdryrun) {
@@ -288,6 +289,7 @@ class curl_step extends flow_step {
                 'destination' => $destination,
             ]);
         }
-        return true;
+
+        return $input;
     }
 }

--- a/classes/local/step/curl_step.php
+++ b/classes/local/step/curl_step.php
@@ -43,7 +43,7 @@ class curl_step extends flow_step {
      * @return  bool whether or not this step has a side effect
      */
     public function has_side_effect(): bool {
-        if (isset($this->stepdef)) {
+        if (!empty($this->stepdef->id)) {
             $config = $this->stepdef->config;
 
             // Destination is outside of scratch directory.

--- a/classes/local/step/curl_step.php
+++ b/classes/local/step/curl_step.php
@@ -1,0 +1,293 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\step;
+
+use Symfony\Component\Yaml\Yaml;
+use tool_dataflows\helper;
+
+/**
+ * CURL step
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @author     Ghaly Marc-Alexandre <marc-alexandreghaly@catalyst-ca.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class curl_step extends flow_step {
+
+    /** @var int time after which curl request is aborted */
+    protected $timeout = 60;
+
+    /**
+     * Returns whether or not the step configured, has a side effect.
+     *
+     * For curl connectors, it is considered to have a side effect if the target is
+     * anywhere outside of the scratch directory, the method is anything other than
+     * 'get' or 'head', or if the 'has side effects' setting is checked.
+     *
+     * @return  bool whether or not this step has a side effect
+     */
+    public function has_side_effect(): bool {
+        if (isset($this->stepdef)) {
+            $config = $this->stepdef->config;
+
+            // Destination is outside of scratch directory.
+            if (!(empty($config->destination) || helper::path_is_relative($config->destination))) {
+                return true;
+            }
+
+            // Request is anything other than 'get' or 'head'.
+            if (!($config->method == 'get' || $config->method == 'head')) {
+                return true;
+            }
+
+            // Side effects setting is checked.
+            return !empty($config->sideeffects);
+        }
+
+        return true;
+    }
+
+    /**
+     * Return the definition of the fields available in this form.
+     *
+     * @return array
+     */
+    public static function form_define_fields(): array {
+        return [
+            'curl' => ['type' => PARAM_TEXT],
+            'destination' => ['type' => PARAM_PATH],
+            'headers' => ['type' => PARAM_RAW],
+            'method' => ['type' => PARAM_TEXT],
+            'rawpostdata' => ['type' => PARAM_RAW],
+            'sideeffects' => ['type' => PARAM_RAW],
+            'timeout' => ['type' => PARAM_INT],
+        ];
+    }
+
+    /**
+     * A list of outputs and their description if applicable.
+     *
+     * These fields can be used as aliases in the custom output mapping
+     *
+     * @return  array of outputs
+     */
+    public function define_outputs(): array {
+        return [
+            'dbgcommand' => null,
+            'response' => [
+                'result' => get_string('connector_curl:output_response_result', 'tool_dataflows'),
+                'info' => [
+                    'http_code' => null,
+                    'connect_time' => null,
+                    'total_time' => null,
+                    'size_upload' => null,
+                    '*' => null,
+                ],
+                'destination' => get_string('connector_curl:destination', 'tool_dataflows'),
+            ],
+        ];
+    }
+
+    /**
+     * Allows each step type to determine a list of optional/required form
+     * inputs for their configuration
+     *
+     * It's recommended you prefix the additional config related fields to avoid
+     * conflicts with any existing fields.
+     *
+     * @param \MoodleQuickForm $mform
+     */
+    public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
+        $jsonexample = [
+            'header-key' => 'header value',
+            'another-key' => '1234',
+        ];
+        $ex['json'] = \html_writer::nonempty_tag('pre', json_encode($jsonexample, JSON_PRETTY_PRINT));
+        $ex['yaml'] = '<pre>header-key: header value<br>another-key: 1234</pre>';
+
+        $urlarray = [];
+        $urlarray[] =& $mform->createElement('select', 'config_method', '', [
+            'get'    => 'GET',
+            'post'   => 'POST',
+            'head'   => 'HEAD',
+            'patch'  => 'PATCH',
+            'put'    => 'PUT',
+        ]);
+        $urlarray[] =& $mform->createElement('text', 'config_curl', '');
+
+        $mform->addGroup($urlarray, 'buttonar', get_string('connector_curl:curl', 'tool_dataflows'), [' '], false);
+        $mform->addRule('buttonar', get_string('required'), 'required', null, 'server');
+
+        $mform->addElement('textarea', 'config_headers', get_string('connector_curl:headers', 'tool_dataflows'),
+                ['cols' => 50, 'rows' => 7]);
+        $mform->addElement('static', 'headers_help', '', get_string('connector_curl:field_headers_help', 'tool_dataflows', $ex));
+
+        $mform->addElement('textarea' , 'config_rawpostdata', get_string('connector_curl:rawpostdata', 'tool_dataflows'),
+                ['cols' => 50, 'rows' => 7]);
+
+        $mform->addElement('text', 'config_destination', get_string('connector_curl:destination', 'tool_dataflows'));
+        $mform->addHelpButton('config_destination', 'connector_curl:destination', 'tool_dataflows');
+        $mform->addElement('static', 'config_path_help', '',  get_string('path_help', 'tool_dataflows').
+            \html_writer::nonempty_tag('pre', get_string('path_help_examples', 'tool_dataflows')));
+
+        $mform->addElement('checkbox', 'config_sideeffects', get_string('connector_curl:sideeffects', 'tool_dataflows'),
+                get_string('yes'));
+        $mform->addHelpButton('config_sideeffects', 'connector_curl:sideeffects', 'tool_dataflows');
+
+        $mform->hideIf('config_rawpostdata', 'config_method', 'eq', 'get');
+        $mform->disabledIf('config_rawpostdata', 'config_method', 'eq', 'get');
+
+        $mform->addElement('text', 'config_timeout', get_string('connector_curl:timeout', 'tool_dataflows'));
+        $mform->addHelpButton('config_timeout', 'connector_curl:timeout', 'tool_dataflows');
+    }
+
+    /**
+     * Validate the configuration settings.
+     *
+     * @param object $config
+     * @return true|\lang_string[] true if valid, an array of errors otherwise
+     */
+    public function validate_config($config) {
+        $errors = [];
+        if (empty($config->curl)) {
+            $errors['config_curl'] = get_string('config_field_missing', 'tool_dataflows', 'curl', true);
+        }
+        if (empty($config->rawpostdata) && ($config->method === 'put' || $config->method === 'post')) {
+            $errors['config_rawpostdata'] = get_string('config_field_missing', 'tool_dataflows', 'rawpostdata', true);
+        }
+        return empty($errors) ? true : $errors;
+    }
+
+    /**
+     * Perform any extra validation that is required only for runs.
+     *
+     * @return true|array Will return true or an array of errors.
+     */
+    public function validate_for_run() {
+        $config = $this->stepdef->config;
+
+        if (!empty($config->destination)) {
+            $error = helper::path_validate($config->destination);
+            if ($error !== true) {
+                return ['config_destination' => $error];
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Performs a cURL call with the provided configuration.
+     *
+     * @return bool|object Returns false on failure, otherwise passes the input through.
+     */
+    public function execute($input) {
+        // Get variables.
+        $config = $this->enginestep->stepdef->config;
+        $isdryrun = $this->enginestep->engine->isdryrun;
+        $method = $config->method;
+
+        $this->enginestep->log($config->curl);
+
+        $dbgcommand = 'curl -X ' .  strtoupper($method) . ' ' . $config->curl;
+        $result = null;
+
+        if (!empty($config->timeout)) {
+            $this->timeout = (int) $config->timeout;
+            $dbgcommand .= ' --max-time ' . $config->timeout;
+        }
+
+        $options = ['CURLOPT_TIMEOUT' => $this->timeout];
+
+        if ($method === 'post') {
+            $options['CURLOPT_POST'] = 1;
+        }
+
+        if ($method === 'put') {
+            $options['CURLOPT_PUT'] = 1;
+        }
+
+        $curl = new \curl();
+
+        // Provided a header is specified add header to request.
+        if (!empty($config->headers)) {
+            $headers = $config->headers;
+            if (!is_array($headers)) {
+                $headers = json_decode($headers, true);
+            }
+            if (is_null($headers)) {
+                $headers = Yaml::parse($config->headers);
+            }
+            $curl->setHeader($headers);
+            $dbgcommand .= ' -H \'' . $config->headers . '\'';
+        }
+
+        // Sets post data.
+        if (!empty($config->rawpostdata)) {
+            $options['CURLOPT_POSTFIELDS'] = $config->rawpostdata;
+            $dbgcommand .= ' -d \'' . $config->rawpostdata . '\'';
+        }
+
+        // Download response to file provided destination is set.
+        if (!empty($config->destination) && !$isdryrun) {
+            if ($config->destination[0] === '/') {
+                $config->destination = ltrim($config->destination, '/');
+            }
+            $config->destination = $this->enginestep->engine->resolve_path($config->destination);
+            $file = fopen($config->destination, 'w');
+            $options['CURLOPT_FILE'] = $file;
+        }
+
+        // Perform call.
+        if (!$isdryrun) {
+            $result = $curl->$method($config->curl, [], $options);
+        }
+
+        if (!empty($file)) {
+            fclose($file);
+        }
+
+        $info = $curl->get_info();
+        // Stores response to be reusable by other steps.
+        // TODO : Once set_var api is refactored add response.
+        $response = $curl->getResponse();
+        $httpcode = $info['http_code'] ?? null;
+        $destination = !empty($config->destination) ? $config->destination : null;
+        $errno = $curl->get_errno();
+
+        if (($httpcode >= 400 || empty($response) || $errno == 28) && !$isdryrun) {
+            throw new \moodle_exception($httpcode . ':' . $result);
+        }
+
+        // Log the raw curl command.
+        $this->enginestep->log($dbgcommand);
+        $this->set_variables('dbgcommand', $dbgcommand);
+
+        if (!$isdryrun) {
+            // TODO: It would be good to define and list any fixed but exposed
+            // fields which the user can use and map to on the edit page.
+            $this->set_variables('response', (object) [
+                'result' => $result,
+                'info' => (object) $info,
+                'destination' => $destination,
+            ]);
+        }
+        return true;
+    }
+}

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -16,6 +16,7 @@
 
 namespace tool_dataflows\local\step;
 
+use tool_dataflows\local\execution\connector_engine_step;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\engine_step;
 use tool_dataflows\local\execution\iterators\iterator;
@@ -43,6 +44,9 @@ abstract class flow_step extends base_step {
      * @return bool
      */
     final public function is_flow(): bool {
+        if ($this->stepdef->id === 131) {
+            return false;
+        }
         return true;
     }
 
@@ -69,13 +73,12 @@ abstract class flow_step extends base_step {
      * @return engine_step
      */
     protected function generate_engine_step(engine $engine): engine_step {
-        return new flow_engine_step($engine, $this->stepdef, $this);
-        if (!isset($this->enginestep)) {
-            $enginestep = new flow_engine_step($engine, $this->stepdef, $this);
-            $this->enginestep = $enginestep;
+        // Determine if it should return a flow (iterator based) or connector (no iterator) engine step.
+        if ($this->is_flow()) {
+            return new flow_engine_step($engine, $this->stepdef, $this);
+        } else {
+            return new connector_engine_step($engine, $this->stepdef, $this);
         }
-
-        return $this->enginestep;
     }
 
     /**

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -65,23 +65,6 @@ abstract class flow_step extends base_step {
     }
 
     /**
-     * Generates an engine step for this type.
-     *
-     * This should be sufficient for most cases. Override this function if needed.
-     *
-     * @param engine $engine
-     * @return engine_step
-     */
-    protected function generate_engine_step(engine $engine): engine_step {
-        // Determine if it should return a flow (iterator based) or connector (no iterator) engine step.
-        if ($this->is_flow()) {
-            return new flow_engine_step($engine, $this->stepdef, $this);
-        } else {
-            return new connector_engine_step($engine, $this->stepdef, $this);
-        }
-    }
-
-    /**
      * Get the iterator for the step, based on configurations.
      *
      * @return iterator

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -44,7 +44,7 @@ abstract class flow_step extends base_step {
      * @return bool
      */
     final public function is_flow(): bool {
-        if ($this->stepdef->id === 131) {
+        if ($this->stepdef->connector == 1) {
             return false;
         }
         return true;
@@ -92,16 +92,32 @@ abstract class flow_step extends base_step {
      */
     public function get_node_styles(): array {
         $basestyles = parent::get_node_styles();
-        $styles = [
-            'shape'     => 'rect',
-            'fillcolor' => '#8cd0db',
-            'fontcolor' => '#000000',
-            'style'     => 'filled,rounded',
-        ];
 
-        if ($this->has_side_effect()) {
-            $styles['fillcolor'] = '#008196';
-            $styles['fontcolor'] = '#ffffff';
+        if ($this->is_flow()) {
+            // Flow styles.
+            $styles = [
+                'shape'     => 'rect',
+                'fillcolor' => '#8cd0db',
+                'fontcolor' => '#000000',
+                'style'     => 'filled,rounded',
+            ];
+
+            if ($this->has_side_effect()) {
+                $styles['fillcolor'] = '#008196';
+                $styles['fontcolor'] = '#ffffff';
+            }
+        } else {
+            // Connector styles.
+            $styles = [
+                'shape'     => 'record',
+                'fillcolor' => '#cccccc',
+            ];
+
+            if ($this->has_side_effect()) {
+                $styles['shape']     = 'rect';
+                $styles['style']     = 'filled';
+                $styles['fillcolor'] = '#ffc107';
+            }
         }
 
         return array_merge($basestyles, $styles);

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -70,6 +70,12 @@ abstract class flow_step extends base_step {
      */
     protected function generate_engine_step(engine $engine): engine_step {
         return new flow_engine_step($engine, $this->stepdef, $this);
+        if (!isset($this->enginestep)) {
+            $enginestep = new flow_engine_step($engine, $this->stepdef, $this);
+            $this->enginestep = $enginestep;
+        }
+
+        return $this->enginestep;
     }
 
     /**

--- a/classes/step.php
+++ b/classes/step.php
@@ -106,6 +106,7 @@ class step extends persistent {
             'description' => ['type' => PARAM_TEXT, 'default' => ''],
             'type' => ['type' => PARAM_TEXT],
             'name' => ['type' => PARAM_TEXT],
+            'connector' => ['type' => PARAM_BOOL, 'default' => false],
             'config' => ['type' => PARAM_TEXT, 'default' => ''],
             'timecreated' => ['type' => PARAM_INT, 'default' => 0],
             'userid' => ['type' => PARAM_INT, 'default' => 0],
@@ -829,7 +830,7 @@ class step extends persistent {
         $classname = $this->type;
         if (class_exists($classname)) {
             // Styles specific for this step type.
-            $steptype = new $classname();
+            $steptype = $this->steptype;
             $stepstyles = $steptype->get_node_styles();
         } else {
             // Invalid step type styles.

--- a/classes/step.php
+++ b/classes/step.php
@@ -704,6 +704,7 @@ class step extends persistent {
      * @throws \coding_exception
      */
     protected function validate_links(array $deps, string $inputoutput) {
+        return true;
         $count = count($deps);
         $errors = [];
 

--- a/classes/step.php
+++ b/classes/step.php
@@ -239,9 +239,16 @@ class step extends persistent {
 
         // Normally expressions are parsed when evaluating the statement, for use in a dataflow run.
         if ($expressions) {
+            // Get variables, based on whether the engine is running or is idle.
+            $enginestep = $steptype->get_engine_step();
+            if ($enginestep) {
+                $variables = $enginestep->get_variables();
+            } else {
+                $variables = $this->variables;
+            }
+
             // Prepare this as a php object (stdClass), as it makes expressions easier to write.
             $parser = new parser();
-            $variables = $this->variables;
             $yaml = $parser->evaluate_recursive($yaml, $variables);
 
             // Sets it to the parsed results.

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/dataflows/db" VERSION="20220720" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
+<XMLDB PATH="admin/tool/dataflows/db" VERSION="20220806" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -37,6 +37,7 @@
         <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user who created this record"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The time this record was modified."/>
         <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Who last modified this record?"/>
+        <FIELD NAME="connector" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Whether or not this step behaves like a connector (WIP)"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -128,5 +128,21 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         }
     }
 
+
+    if ($oldversion < 2022080600) {
+
+        // Define field connector to be added to tool_dataflows_steps.
+        $table = new xmldb_table('tool_dataflows_steps');
+        $field = new xmldb_field('connector', XMLDB_TYPE_INTEGER, '1', null, null, null, null, 'usermodified');
+
+        // Conditionally launch add field connector.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Dataflows savepoint reached.
+        upgrade_plugin_savepoint(true, 2022080600, 'tool', 'dataflows');
+    }
+
     return true;
 }

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -104,7 +104,7 @@ $string['endstate'] = 'End state';
 $string['strftimedatetimeaccurate'] = '%d %B %Y, %I:%M:%S %p';
 
 // Step names.
-$string['step_name_curl_step'] = 'cURL';
+$string['step_name_curl'] = 'cURL';
 $string['step_name_connector_curl'] = 'Curl connector';
 $string['step_name_connector_debugging'] = 'Debugging connector';
 $string['step_name_connector_s3'] = 'S3 file copy connector';

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -104,6 +104,7 @@ $string['endstate'] = 'End state';
 $string['strftimedatetimeaccurate'] = '%d %B %Y, %I:%M:%S %p';
 
 // Step names.
+$string['step_name_curl_step'] = 'cURL';
 $string['step_name_connector_curl'] = 'Curl connector';
 $string['step_name_connector_debugging'] = 'Debugging connector';
 $string['step_name_connector_s3'] = 'S3 file copy connector';

--- a/lib.php
+++ b/lib.php
@@ -48,6 +48,7 @@ function tool_dataflows_after_config() {
  */
 function tool_dataflows_step_types() {
     return [
+        new step\curl_step,
         new step\connector_curl,
         new step\connector_debugging,
         new step\connector_debug_file_display,

--- a/lib.php
+++ b/lib.php
@@ -48,7 +48,7 @@ function tool_dataflows_after_config() {
  */
 function tool_dataflows_step_types() {
     return [
-        new step\curl_step,
+        new step\curl,
         new step\connector_curl,
         new step\connector_debugging,
         new step\connector_debug_file_display,

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022080500;
-$plugin->release = 2022080500;
+$plugin->version = 2022080600;
+$plugin->release = 2022080600;
 
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 


### PR DESCRIPTION
- feat: fill in name of new steps based on step type
- [wip] feat: flow and connector steps can now be used interchangably
- wip: add curl step with dual step support
- wip: adjust curl step, add helper methods to ease authoring
- wip: flip the check in the connector engine step because iterator-esque steps no longer return true. Instead they should explicitly return false when things go bad.
- everybody needs variables, even connectors
- the magic: if the step type is resolved to a flow, then it is a flow step, otherwise it is a connector step.
- refactor: simplify generate_engine_step methods for flow/connector steps
- add connector flag in steps table, update dot graph handling to visually display this change and fix side effect flags
- fix: step chooser / new step form (side quest)
- For connector-like steps, the input isn't real and so should be an empty object.
- changed curl_step to curl, updated handling of prefilled names for new steps
- fix weird issue where has_side_effect wouldn't enter probably magic getters
