### PR TITLE
feat: when creating a new step the name will be prefilled automatically

### DIFF
--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -404,6 +404,11 @@ class step_form extends \core\form\persistent {
             $data = $steptype->form_get_default_data($data);
         }
 
+        // Automatically fill in the name for new steps.
+        if (empty($data->id)) {
+            $data->name = $steptype->get_name();
+        }
+
         return $data;
     }
 


### PR DESCRIPTION
This will be equal to just the class name, and later on, the class names will be simplified to something like 'curl' or 'sql' which will be even better, so opted to not do anything too opinionated here.

Resolves #488
