### PR TITLE
Issue 510: Fix get_export_data()

### DIFF
--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -617,7 +617,14 @@ class engine {
      * @return  array
      */
     public function get_export_data(): array {
-        $cleanvariables = json_decode(json_encode($this->get_variables()), true);
+        $encoded = json_encode($this->get_variables(), defined('JSON_INVALID_UTF8_SUBSTITUTE') ? JSON_INVALID_UTF8_SUBSTITUTE : 0);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \moodle_exception(json_last_error_msg());
+        }
+        $cleanvariables = json_decode($encoded, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \moodle_exception(json_last_error_msg());
+        }
         return $cleanvariables;
     }
 

--- a/classes/run.php
+++ b/classes/run.php
@@ -45,9 +45,9 @@ class run extends persistent {
             'timestarted' => ['type' => PARAM_FLOAT, 'default' => 0],
             'timepaused' => ['type' => PARAM_FLOAT, 'default' => 0],
             'timefinished' => ['type' => PARAM_FLOAT, 'default' => 0],
-            'startstate' => ['type' => PARAM_TEXT, 'default' => ''],
-            'currentstate' => ['type' => PARAM_TEXT, 'default' => ''],
-            'endstate' => ['type' => PARAM_TEXT, 'default' => ''],
+            'startstate' => ['type' => PARAM_RAW, 'default' => ''],
+            'currentstate' => ['type' => PARAM_RAW, 'default' => ''],
+            'endstate' => ['type' => PARAM_RAW, 'default' => ''],
         ];
     }
 


### PR DESCRIPTION
Resolves #510 

The fix used is not available in PHP 7.1. So in 7.1, the sample given will result in a 'Malformed UTF-8 characters, possibly incorrectly encoded' exception.