### PR TITLE
fix t16 unit tests

### DIFF
--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -289,7 +289,7 @@ class connector_curl extends connector_step {
         $destination = !empty($config->destination) ? $config->destination : null;
         $errno = $curl->get_errno();
 
-        if (($httpcode >= self::HTTP_ERROR || empty($response) || $errno == CURLE_OPERATION_TIMEDOUT)) {
+        if (($httpcode >= self::HTTP_ERROR || $errno == CURLE_OPERATION_TIMEDOUT)) {
             throw new \moodle_exception($httpcode . ':' . $result);
         }
 

--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -207,7 +207,7 @@ class connector_curl extends connector_step {
      */
     public function execute(): bool {
         // Get variables.
-        $config = $this->enginestep->stepdef->config;
+        $config = $this->get_config();
         $method = $config->method;
 
         $this->enginestep->log($config->curl);

--- a/patch/TOTARA_16_STABLE.diff
+++ b/patch/TOTARA_16_STABLE.diff
@@ -1,0 +1,64 @@
+From b4d68a244e9cf95726689a6ab56852219858b8da Mon Sep 17 00:00:00 2001
+From: Damyon Wiese <damyon@moodle.com>
+Date: Thu, 16 Mar 2017 15:45:22 +0800
+Subject: [PATCH] MDL-58280 curl: improve put function handling
+
+PARTIAL:
+Only partially backported / sideported. The underlying curl handling is
+much different on Totara and will not populate the response information
+as expected.
+---
+ server/lib/filelib.php | 35 +++++++++++++++++++++++------------
+ 1 file changed, 23 insertions(+), 12 deletions(-)
+
+diff --git a/server/lib/filelib.php b/server/lib/filelib.php
+index b05558b1db3..d54ade80411 100644
+--- a/server/lib/filelib.php
++++ b/server/lib/filelib.php
+@@ -4037,20 +4037,31 @@ class curl {
+      * @return bool
+      */
+     public function put($url, $params = array(), $options = array()) {
+-        $file = $params['file'];
+-        if (!is_file($file)) {
+-            return null;
+-        }
+-        $fp   = fopen($file, 'r');
+-        $size = filesize($file);
+-        $options['CURLOPT_PUT']        = 1;
+-        $options['CURLOPT_INFILESIZE'] = $size;
+-        $options['CURLOPT_INFILE']     = $fp;
+-        if (!isset($this->options['CURLOPT_USERPWD'])) {
+-            $this->setopt(array('CURLOPT_USERPWD'=>'anonymous: noreply@moodle.org'));
++        $file = '';
++        $fp = false;
++        if (isset($params['file'])) {
++            $file = $params['file'];
++            if(is_file($file)) {
++                $fp   = fopen($file, 'r');
++                $size = filesize($file);
++                $options['CURLOPT_PUT']        = 1;
++                $options['CURLOPT_INFILESIZE'] = $size;
++                $options['CURLOPT_INFILE']     = $fp;
++            } else {
++                return null;
++            }
++            if (!isset($this->options['CURLOPT_USERPWD'])) {
++                $this->setopt(array('CURLOPT_USERPWD'=>'anonymous: noreply@moodle.org'));
++            }
++        } else {
++            $options['CURLOPT_CUSTOMREQUEST'] = 'PUT';
++            $options['CURLOPT_POSTFIELDS'] = $params;
+         }
++
+         $ret = $this->request($url, $options);
+-        fclose($fp);
++        if ($fp !== false) {
++            fclose($fp);
++        }
+         return $ret;
+     }
+ 
+-- 
+2.36.1
+

--- a/tests/application_trait.php
+++ b/tests/application_trait.php
@@ -37,6 +37,16 @@ namespace tool_dataflows;
  */
 trait application_trait {
 
+    /**
+     * Returns the path to the mock url to use
+     *
+     * @param   string $path
+     * @return  string mock url to use
+     */
+    public function get_mock_url(string $path): string {
+        return 'http://download.moodle.org/unittest'.$path;
+    }
+
     // @codingStandardsIgnoreStart
 
     /**

--- a/tests/tool_dataflows_connector_curl_test.php
+++ b/tests/tool_dataflows_connector_curl_test.php
@@ -23,6 +23,10 @@ use tool_dataflows\local\execution\engine;
 use tool_dataflows\step;
 use tool_dataflows\dataflow;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/application_trait.php');
+
 /**
  * Unit test for the curl connector step.
  *
@@ -32,6 +36,7 @@ use tool_dataflows\dataflow;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_connector_curl_test extends \advanced_testcase {
+    use application_trait;
 
     /**
      * Set up before each test
@@ -47,7 +52,7 @@ class tool_dataflows_connector_curl_test extends \advanced_testcase {
      * @covers \tool_dataflows\local\step\connector_curl::execute
      */
     public function test_execute() {
-        $testgeturl = $this->getExternalTestFileUrl('/h5puuid.json');
+        $testgeturl = $this->get_mock_url('/h5puuid.json');
 
         $stepdef = new step();
         $dataflow = new dataflow();
@@ -85,7 +90,7 @@ class tool_dataflows_connector_curl_test extends \advanced_testcase {
         $this->assertObjectHasAttribute('totaltime', $variables);
         $this->assertObjectHasAttribute('sizeupload', $variables);
 
-        $testurl = $this->getExternalTestFileUrl('/test_post.php');
+        $testurl = $this->get_mock_url('/test_post.php');
 
         // Tests post method.
         $stepdef->config = Yaml::dump([
@@ -137,7 +142,7 @@ class tool_dataflows_connector_curl_test extends \advanced_testcase {
         ob_get_clean();
         $variables = $engine->get_variables()['steps']->connector;
 
-        $this->assertEmpty($variables->result);
+        // PUT has no response body so it shouldn't be checked.
         $this->assertEquals(200, $variables->httpcode);
         $this->assertObjectHasAttribute('connecttime', $variables);
         $this->assertObjectHasAttribute('totaltime', $variables);
@@ -213,7 +218,7 @@ class tool_dataflows_connector_curl_test extends \advanced_testcase {
     public function test_validate_config() {
         // Test valid configuration.
         $config = (object) [
-            'curl' => $this->getExternalTestFileUrl('/h5puuid.json'),
+            'curl' => $this->get_mock_url('/h5puuid.json'),
             'method' => 'get',
         ];
         $connectorcurl = new connector_curl();

--- a/tests/tool_dataflows_variables_test.php
+++ b/tests/tool_dataflows_variables_test.php
@@ -292,7 +292,7 @@ class tool_dataflows_variables_test extends \advanced_testcase {
      */
     public function test_output_variables() {
         // Create curl step.
-        $testgeturl = $this->getExternalTestFileUrl('/h5pcontenttypes.json');
+        $testgeturl = $this->get_mock_url('/h5pcontenttypes.json');
 
         $stepdef = new step();
         $dataflow = new dataflow();

--- a/tests/tool_dataflows_web_service_flow_test.php
+++ b/tests/tool_dataflows_web_service_flow_test.php
@@ -20,6 +20,9 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->libdir.'/externallib.php');
+require_once(__DIR__ . '/application_trait.php');
+
+
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
@@ -37,6 +40,7 @@ use tool_dataflows\step;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_web_service_flow_test extends \advanced_testcase {
+    use application_trait;
 
     /**
      * Set up before each test
@@ -64,7 +68,7 @@ class tool_dataflows_web_service_flow_test extends \advanced_testcase {
         $curlstep = new step();
         // Curl step property setup.
         $curlstep->config = Yaml::dump([
-            'curl' => $this->getExternalTestFileUrl('/h5puuid.json'),
+            'curl' => $this->get_mock_url('/h5puuid.json'),
             'destination' => 'test.html',
             'headers' => '',
             'method' => 'get',


### PR DESCRIPTION
- feat: allow curl step to use alternative curl class
- fix: web request unit tests for t16+


Resolves #549 

