### PR TITLE
fix: default dependson to an empty array if null

### DIFF
--- a/step.php
+++ b/step.php
@@ -106,7 +106,7 @@ if (($data = $form->get_data())) {
             // If we don't have an ID, we know that we must create a new record.
             // Call your API to create a new persistent from this data.
             // Or, do the following if you don't want capability checks (discouraged).
-            $dependson = $data->dependson;
+            $dependson = $data->dependson ?? [];
             unset($data->dependson);
             $persistent = new step(0, $data);
             // Only unset field (as it should be set based on the name) if it is empty.


### PR DESCRIPTION
In this case, they would mean the same thing, but for now the caller will ensure the data is passed to the method in the right format

Resolves #561
