### PR TITLE
Issue #579: Change version of output remappings.

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -150,7 +150,19 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022090600, 'tool', 'dataflows');
     }
 
-    if ($oldversion < 2022090700 ) {
+    if ($oldversion < 2022090700) {
+        // Rename field group on table tool_dataflows_logs to loggroup.
+        $table = new xmldb_table('tool_dataflows_logs');
+        $field = new xmldb_field('group', XMLDB_TYPE_CHAR, '50', null, null, null, null, 'level');
+
+        // Launch rename field loggroup.
+        $dbman->rename_field($table, $field, 'loggroup');
+
+        // Dataflows savepoint reached.
+        upgrade_plugin_savepoint(true, 2022090700, 'tool', 'dataflows');
+    }
+
+    if ($oldversion < 2022091200) {
         // Changing type of field config on table tool_dataflows_steps to text.
         $table = new xmldb_table('tool_dataflows');
 
@@ -190,19 +202,7 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         }
 
         // Dataflows savepoint reached.
-        upgrade_plugin_savepoint(true, 2022090700, 'tool', 'dataflows');
-    }
-
-    if ($oldversion < 2022090700) {
-        // Rename field group on table tool_dataflows_logs to loggroup.
-        $table = new xmldb_table('tool_dataflows_logs');
-        $field = new xmldb_field('group', XMLDB_TYPE_CHAR, '50', null, null, null, null, 'level');
-
-        // Launch rename field loggroup.
-        $dbman->rename_field($table, $field, 'loggroup');
-
-        // Dataflows savepoint reached.
-        upgrade_plugin_savepoint(true, 2022090700, 'tool', 'dataflows');
+        upgrade_plugin_savepoint(true, 2022091200, 'tool', 'dataflows');
     }
 
     return true;

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022090700;
-$plugin->release = 2022090700;
+$plugin->version = 2022091200;
+$plugin->release = 2022091200;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Resolves #579

It should not cause any problems if the database has already been updated.

The diff shows the logroup block being shifted, when it was the output remapping group that was shifted.
