### PR TITLE
misc bugfix and improvements

### DIFF
--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -139,6 +139,12 @@ class dataflow_iterator implements iterator {
      * @return  \stdClass|bool A JSON compatible \stdClass, or false if nothing returned.
      */
     public function next($caller) {
+        // Record the timestamp of when the step type handling has been entered
+        // into. This should be set as early as possible to encapsulate the time
+        // it takes.
+        $now = microtime(true);
+        $this->steptype->set_variables('timeentered', $now);
+
         if ($this->finished) {
             return false;
         }
@@ -176,6 +182,10 @@ class dataflow_iterator implements iterator {
             $this->steptype->prepare_vars();
 
             ++$this->iterationcount;
+
+            // Expose the number of times this step has been iterated over.
+            $this->steptype->set_variables('iterations', $this->iterationcount);
+
             $this->step->log('Iteration ' . $this->iterationcount . ': ' . json_encode($newvalue));
         } catch (\Throwable $e) {
             $this->step->log($e->getMessage());

--- a/classes/runs_table.php
+++ b/classes/runs_table.php
@@ -133,6 +133,6 @@ class runs_table extends sql_table {
      */
     public function col_duration(\stdClass $record): string {
         $totalsecs = number_format($record->timefinished - $record->timestarted, 3);
-        return format_time($totalsecs);
+        return format_time((float) $totalsecs);
     }
 }

--- a/classes/step.php
+++ b/classes/step.php
@@ -74,7 +74,14 @@ class step extends persistent {
      */
     public function __construct(...$args) {
         parent::__construct(...$args);
-        $this->states = new \stdClass;
+
+        // Ensure all states can be referenced, defaulting them to null.
+        $this->states = (object) array_combine(
+            // All the labels.
+            engine::STATUS_LABELS,
+            // Filled with null.
+            array_fill(0, count(engine::STATUS_LABELS), null)
+        );
     }
 
     /**

--- a/step.php
+++ b/step.php
@@ -123,7 +123,7 @@ if (($data = $form->get_data())) {
             // We had an ID, this means that we are going to update a record.
             // Call your API to update the persistent from the data.
             // Or, do the following if you don't want capability checks (discouraged).
-            $dependson = $data->dependson;
+            $dependson = $data->dependson ?? [];
             unset($data->dependson);
             // Only unset field (as it should be set based on the name) if it is empty.
             if (empty($data->alias)) {

--- a/styles.css
+++ b/styles.css
@@ -142,3 +142,8 @@ tr:where(.field_timestarted, .field_timefinished) {
 .tool_dataflow-output :hover {
     background: #333;
 }
+.tool_dataflow-output > * {
+    background: #111;
+    color: #eee;
+    font-size: 1em;
+}

--- a/tests/tool_dataflows_workflow_state_test.php
+++ b/tests/tool_dataflows_workflow_state_test.php
@@ -108,7 +108,7 @@ class tool_dataflows_workflow_state_test extends \advanced_testcase {
         // Yet the same.
         $this->assertEquals($initialdata['dataflow']['id'], $finaldata['dataflow']['id']);
         // Only the "new" state should be set.
-        $this->assertCount(1, $initialdata['steps']['reader']['states']);
+        $this->assertCount(1, array_filter($initialdata['steps']['reader']['states']));
         // But by the end, more state timestamps should have been added.
         $this->assertGreaterThan(1, $finaldata['steps']['reader']['states']);
         // But it should still hold the same new value it once had.

--- a/view-run.php
+++ b/view-run.php
@@ -108,7 +108,7 @@ $data = [
         get_string('strftimedatetimeaccurate', 'tool_dataflows'),
         $defaulttimezone
     ),
-    'field_duration' => $duration ? format_time($duration) : ("0 {$secsstr}"),
+    'field_duration' => $duration ? format_time((float) $duration) : ("0 {$secsstr}"),
 ];
 $tabledata = [];
 foreach ($data as $key => $value) {


### PR DESCRIPTION
- style: tweak to allow any debugging to come through visible and clear
  for example: anything outputted in pre tags will stay the same font size
- fix: depends on must be an array, not null
- fix(runs): table display, set param type to float, expect float/int but received string
- fix: state timestamps can be referenced at any time
  This means usage across steps won't be dependent on that state having existed prior to checking. The default value is null.
