### PR TITLE
Issue #392: Improve handling of curl headers in connector_curl

### DIFF
--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -332,7 +332,7 @@ ORDER BY id ASC
      *
      * @param  \stdClass $value
      */
-    public function execute($value) {
+    public function execute($value = null) {
         // Check the config for the counterfield.
         $config = $this->enginestep->stepdef->config;
         $counterfield = $config->counterfield ?? null;

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -376,8 +376,10 @@ $string['connector_curl:sideeffects'] = 'Does this request have side effects?';
 $string['connector_curl:sideeffects_help'] = 'Most read requests done via http GET do not have side effects ie they change state on the remote server, and generally any POST or PUT does have side effects. Curl calls with side effects are not actually executed in dry run mode.';
 $string['connector_curl:timeout'] = 'Timeout';
 $string['connector_curl:timeout_help'] = 'Time in seconds after which the request will abort, default is 60 seconds.';
-$string['connector_curl:field_headers_help'] = 'Headers should be in the following JSON format: {$a->json} You can also use the following YAML format: {$a->yaml}';
+$string['connector_curl:field_headers_help'] = 'Headers should be in valid HTTP format: {$a} One per line.';
 $string['connector_curl:output_response_result'] = 'Returns a string that contains the response to the request as text, or null if the request was unsuccessful or has not yet been sent.';
+$string['connector_curl:header_format'] = '<header>:<value>';
+$string['connector_curl:headers_invalid'] = 'Curl connector headers are invalid.';
 
 // Checks.
 $string['check:dataflows_completed_successfully'] = 'All recent dataflow runs completed successfully.';

--- a/tests/tool_dataflows_helper_test.php
+++ b/tests/tool_dataflows_helper_test.php
@@ -75,4 +75,59 @@ class tool_dataflows_helper_test extends \advanced_testcase {
             ],
         ];
     }
+
+    /**
+     * Tests the bash_escape() function.
+     *
+     * @dataProvider bash_escape_provider
+     * @covers \tool_dataflows\helper::bash_escape
+     * @param string $value
+     * @param string $expected
+     */
+    public function test_bash_escape(string $value, string $expected) {
+        $this->assertEquals($expected, helper::bash_escape($value));
+    }
+
+    /**
+     * Provider for test_bash_escape().
+     *
+     * @return \string[][]
+     */
+    public function bash_escape_provider(): array {
+        return [
+            ['', "''"],
+            ['something with a space', "'something with a space'"],
+            ['something with a \' quote', "'something with a '\'' quote'"],
+        ];
+    }
+
+    /**
+     * Tests extract_http_headers()
+     *
+     * @dataProvider extract_http_headers_provider
+     * @covers \tool_dataflows\helper::extract_http_headers
+     * @param string $content
+     * @param array|bool $expected
+     */
+    public function test_extract_http_headers(string $content, $expected) {
+        $this->assertEquals($expected, helper::extract_http_headers($content));
+    }
+
+    /**
+     * Data provider for test_extract_http_headers().
+     *
+     * @return array[]
+     */
+    public function extract_http_headers_provider(): array {
+        return [
+            ['', []],
+            ['0', false],
+            ['X-one: one', ['X-one' => ' one']],
+            ["X-one: one\n two", ['X-one' => ' one two']],
+            ["X-one: one\n two\nX-two:two\nX-three:three", ['X-one' => ' one two', 'X-two' => 'two', 'X-three' => 'three']],
+            ["X-one: one\n two\n \nX-two:two\nX-three:three", false],
+            ["X-one: one\n two\nX-two\nX-three:three", false],
+            ["X-@one: one\n two\nX-two:two\nX-three:three", false],
+        ];
+    }
 }

--- a/tests/tool_dataflows_variables_test.php
+++ b/tests/tool_dataflows_variables_test.php
@@ -309,6 +309,7 @@ class tool_dataflows_variables_test extends \advanced_testcase {
             'curl' => $testgeturl,
             'destination' => '',
             'headers' => '',
+            'timeout' => '0',
             'method' => 'get',
         ]);
 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022091500;
-$plugin->release = 2022091500;
+$plugin->version = 2022091600;
+$plugin->release = 2022091600;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Resolves #392 

Refactor code to handle headers as plain text
Handle multiple headers in bash command.
Add bash escaping.
Other fixes.