### PR TITLE
fix(parser): warning for undefined properties

### DIFF
--- a/classes/parser.php
+++ b/classes/parser.php
@@ -165,7 +165,7 @@ class parser {
                 // the wrong spot.
                 try {
                     $parsethis = trim($match['expression']);
-                    error_reporting(E_ALL & ~E_NOTICE);
+                    error_reporting(E_ALL & ~E_NOTICE & ~E_WARNING);
                     $result = $this->expressionlanguage->evaluate(
                         $parsethis,
                         $variables


### PR DESCRIPTION
This used to come up as a notice, but now has been changed to a warning which was not suppressed. This removes warnings from display also during parsing.

Resolves #629
