### PR TITLE
614 new variables

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -35,12 +35,6 @@ class dataflow extends persistent {
     /** The table name. */
     const TABLE = 'tool_dataflows';
 
-    /** @var \stdClass of engine step states and timestamps */
-    private $states;
-
-    /** @var engine dataflow engine this dataflow is part of. Note: not always set. */
-    private $engine;
-
     /** @var steps[] cache of steps connected to this dataflow */
     private $stepscache = [];
 
@@ -50,9 +44,6 @@ class dataflow extends persistent {
     /** @var bool If true, then the variables tree will be rebuilt when get_variables() is called.  */
     private $shouldrebuildvariables = true;
 
-    /** @var array The variables tree constructed by get_variables(). */
-    private $variablestree;
-
     /**
      * When initialising the persistent, ensure some internal fields have been set up.
      *
@@ -60,7 +51,6 @@ class dataflow extends persistent {
      */
     public function __construct(...$args) {
         parent::__construct(...$args);
-        $this->states = new \stdClass;
     }
 
     /**
@@ -73,26 +63,6 @@ class dataflow extends persistent {
      */
     public function set_engine(engine $engine) {
         $this->engine = $engine;
-    }
-
-    /**
-     * Updates the timestamp for a particular state that is stored locally on the instance
-     *
-     * @param  int $state a status constant from the engine class
-     * @param  float $timestamp typically from a microtime(true) call
-     */
-    public function set_state_timestamp(int $state, float $timestamp) {
-        $label = engine::STATUS_LABELS[$state];
-        $this->states->{$label} = $timestamp;
-    }
-
-    /**
-     * Returns the states and their timestamps for this step
-     *
-     * @return  \stdClass
-     */
-    public function get_states() {
-        return $this->states;
     }
 
     /**
@@ -143,155 +113,18 @@ class dataflow extends persistent {
     }
 
     /**
-     * Sets the rebuild variables flag, so that the variables tree is rebuilt the next time get_variables() is called.
-     */
-    public function rebuild_variables() {
-        $this->shouldrebuildvariables = true;
-    }
-
-    /**
-     * Returns the variables available for this object
+     * Return the vars of the dataflow.
      *
-     * @return     array of variables typically passed to the expression parser
-     */
-    public function get_variables(): array {
-        if (!$this->shouldrebuildvariables) {
-            // No variables have been set since the last rebuild, so just return the same tree.
-            return $this->variablestree;
-        }
-
-        $globalvars = Yaml::parse(get_config('tool_dataflows', 'global_vars'), Yaml::PARSE_OBJECT_FOR_MAP)
-                ?? new \stdClass();
-
-        // Prepare the list of variables available from each step.
-        $steps = [];
-        foreach ($this->steps as $key => $step) {
-            $steps[$key] = $step->get_export_data();
-            $steps[$key]['alias'] = $key;
-            $steps[$key]['states'] = $step->states;
-            $steps[$key]['config'] = isset($steps[$key]['config']) ? (object) $steps[$key]['config'] : new \stdClass();
-
-            // Store root variables directly under the step.
-            foreach ($step->rootvariables as $somefield => $somevalue) {
-                $steps[$key][$somefield] = $somevalue;
-            }
-
-            // Store vars variables under '.vars'.
-            $steps[$key]['vars'] = new \stdClass();
-            foreach ($step->varsvariables as $somefield => $somevalue) {
-                $steps[$key]['vars']->{$somefield} = $somevalue;
-            }
-        }
-
-        foreach ($steps as &$step) {
-            $step = (object) $step;
-        }
-        $steps = (object) $steps;
-        $parser = new parser();
-
-        $variables = ['steps' => $steps];
-
-        $placeholder = '__PLACEHOLDER__';
-        $max = 100;
-        $foundexpression = true;
-        while ($foundexpression && $max) {
-            $max--;
-            $foundexpression = false;
-            foreach ($steps as &$step) {
-                foreach ($step->config ?? [] as $key => &$field) {
-                    if (!isset($field)) {
-                        continue;
-                    }
-
-                    $localparse = function (&$field)
-                        use ($parser, $variables, $step, $key, $placeholder, &$foundexpression)
-                    {
-                        [$hasexpression] = $parser->has_expression($field);
-                        if ($hasexpression) {
-                            $foundexpression = true;
-                            $fieldvalue = $field;
-                            $field = $placeholder;
-                            $resolved = $parser->evaluate($fieldvalue, $variables);
-                            if ($resolved === $placeholder) {
-                                $link = new \moodle_url('/admin/tool/dataflows/step.php', ['id' => $step->id]);
-                                throw new \moodle_exception(
-                                    'recursiveexpressiondetected',
-                                    'tool_dataflows',
-                                    $link,
-                                    ['field' => $key, 'steptype' => $step->type]
-                                );
-                            }
-                            if (isset($resolved)) {
-                                $field = $resolved;
-                            } else {
-                                $field = $fieldvalue;
-                            }
-                        }
-                    };
-
-                    if (is_object($field)) {
-                        foreach ($field as &$fieldlet) {
-                            if (!is_object($fieldlet) && !is_array($fieldlet)) {
-                                $localparse($fieldlet);
-                            }
-                        }
-                    } else {
-                        $localparse($field);
-                    }
-                }
-            }
-        }
-
-        // Prepare variable data for the dataflow key.
-        $dataflow = (object) $this->get_export_data();
-        unset($dataflow->steps);
-        $dataflow->vars = $this->get_vars(false);
-        $dataflow->states = $this->states;
-        $dataflow->id     = $this->id;
-
-        $url = new \moodle_url('/admin/tool/dataflows/view-run.php', ['id' => $this->engine->run->id ?? 'xxx']);
-        $dataflow->run = (object) [
-            'id'    => $this->engine->run->id ?? null,
-            'name'  => $this->engine->run->name ?? null,
-            'url'   => $url->out(),
-        ];
-
-        // Test reading a value directly.
-        $variables = [
-            'global' => (object) [
-                'vars' => $globalvars,
-                'cfg'  => helper::get_cfg_vars(),
-            ],
-            'dataflow' => $dataflow,
-            'steps'    => $steps,
-        ];
-        $this->variablestree = $variables;
-        $this->shouldrebuildvariables = false;
-        return $variables;
-    }
-
-    /**
-     * Return the vars of the dataflow, parsed such that any
-     * expressions are evaluated at this point in time.
-     *
-     * @param   bool $expressions whether or not to parse expressions when returning the vars
      * @return  \stdClass vars object
      */
-    protected function get_vars($expressions = true): \stdClass {
+    protected function get_vars(): \stdClass {
         $yaml = Yaml::parse($this->raw_get('vars'), Yaml::PARSE_OBJECT_FOR_MAP);
         // If there is no vars, return an empty object.
         if (empty($yaml)) {
             return new \stdClass();
         }
 
-        // If no parsing is required, return the raw YAML object early.
-        if (!$expressions) {
-            return $yaml;
-        }
-
-        // Prepare this as a php object (stdClass), as it makes expressions easier to write.
-        $parser = new parser();
-        return $parser->evaluate_recursive($yaml, $this->variables);
+        return $yaml;
     }
 
     /**
@@ -300,7 +133,7 @@ class dataflow extends persistent {
      * @return \stdClass
      */
     public function get_raw_vars(): \stdClass {
-        return $this->get_vars(false);
+        return $this->get_vars();
     }
 
     /**
@@ -682,7 +515,6 @@ class dataflow extends persistent {
         $step->set_dataflow($this);
         $step->upsert();
         $this->stepscache[$step->id] = $step;
-        $this->rebuild_variables();
         return $this;
     }
 
@@ -694,7 +526,6 @@ class dataflow extends persistent {
      */
     public function remove_step(step $step) {
         $step->delete();
-        $this->rebuild_variables();
         return $this;
     }
 
@@ -705,7 +536,6 @@ class dataflow extends persistent {
         if (!$this->isdeleting) {
             // Not needed if we are going to just delete the dataflow.
             $this->set('confighash', '');
-            $this->rebuild_variables();
             $this->save();
         }
     }
@@ -776,7 +606,6 @@ class dataflow extends persistent {
                 }
             }
             $transaction->allow_commit();
-            $this->rebuild_variables();
         } catch (\Exception $exception) {
             $transaction->rollback($exception);
             throw $exception;
@@ -820,29 +649,6 @@ class dataflow extends persistent {
         }
 
         return $yaml;
-    }
-
-    /**
-     * Updates the value stored in the dataflow's vars
-     *
-     * @param  string $name or path to name of field e.g. 'some.nested.fieldname'
-     * @param  mixed $value
-     */
-    public function set_var($name, $value) {
-        // Grabs the current vars.
-        $vars = $this->vars;
-
-        // Updates the field in question.
-        $vars->{$name} = $value;
-
-        // Updates the stored vars.
-        $this->vars = Yaml::dump(
-            (array) $vars,
-            helper::YAML_DUMP_INLINE_LEVEL,
-            helper::YAML_DUMP_INDENT_LEVEL,
-            Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK
-        );
-        $this->rebuild_variables();
     }
 
     /**

--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -76,18 +76,6 @@ class dataflow extends persistent {
     }
 
     /**
-     * Links the engine up to this dataflow
-     *
-     * This is typically set when the engine is initialised, such that any
-     * references made thereafter are directly connected to the engine's instance being used.
-     *
-     * @param  engine $engine
-     */
-    public function set_engine(engine $engine) {
-        $this->engine = $engine;
-    }
-
-    /**
      * Return the definition of the properties of this model.
      *
      * @return array
@@ -587,7 +575,7 @@ class dataflow extends persistent {
      * Called after the dataflow is created in the DB.
      */
     protected function after_create() {
-        $this->dataflows[$this->id] = $this;
+        self::$dataflows[$this->id] = $this;
     }
 
     /**

--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -295,6 +295,15 @@ class dataflow extends persistent {
     }
 
     /**
+     * Get variables without evaluating expressions.
+     *
+     * @return \stdClass
+     */
+    public function get_raw_vars(): \stdClass {
+        return $this->get_vars(false);
+    }
+
+    /**
      * Returns all the edges with their dependencies
      *
      * @return     array $edges steps and their dependencies (by id)

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -95,7 +95,7 @@ class step_form extends \core\form\persistent {
 
         $select->setMultiple(true);
 
-        $variables = new variables_root(new dataflow($dataflowid));
+        $variables = (new dataflow($dataflowid))->get_variables_root();
 
         // List all the available fields available for configuration, in dot syntax.
         $mform->addElement(

--- a/classes/local/execution/connector_engine_step.php
+++ b/classes/local/execution/connector_engine_step.php
@@ -44,9 +44,9 @@ class connector_engine_step extends engine_step {
         switch ($this->proceed_status()) {
             case self::PROCEED_GO:
                 try {
-                    $this->step->get_variables()->localise();
+                    $this->get_variables()->localise();
                     $result = $this->steptype->execute(new \stdClass);
-                    $this->step->get_variables()->localise(false);
+                    $this->get_variables()->localise(false);
                     $this->steptype->log_vars();
                     if ($result !== false) {
                         $this->set_status(engine::STATUS_FINISHED);

--- a/classes/local/execution/connector_engine_step.php
+++ b/classes/local/execution/connector_engine_step.php
@@ -44,8 +44,10 @@ class connector_engine_step extends engine_step {
         switch ($this->proceed_status()) {
             case self::PROCEED_GO:
                 try {
+                    $this->step->get_variables()->localise();
                     $result = $this->steptype->execute(new \stdClass);
-                    $this->steptype->prepare_vars();
+                    $this->step->get_variables()->localise(false);
+                    $this->steptype->log_vars();
                     if ($result !== false) {
                         $this->set_status(engine::STATUS_FINISHED);
                     } else {

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -136,7 +136,6 @@ class engine {
      */
     public function __construct(dataflow $dataflow, bool $isdryrun = false, $automated = true) {
         $this->dataflow = $dataflow;
-        $this->dataflow->set_engine($this);
         $this->isdryrun = $isdryrun;
         $this->automated = $automated;
 
@@ -318,6 +317,7 @@ class engine {
         foreach ($this->enginesteps as $enginestep) {
             if ($enginestep->is_flow() && $this->count_flow_steps($enginestep->downstreams) == 0) {
                 $step = new \tool_dataflows\step();
+                $step->set_dataflow($this->dataflow);
                 $flowcapnumber++;
                 $step->name = "flowcap-{$flowcapnumber}";
                 $step->type = flow_cap::class;

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -555,64 +555,6 @@ class engine {
     }
 
     /**
-     * Sets a variable at the dataflow level
-     *
-     * Almost 'anything goes' here. Since the dataflow itself doesn't have any
-     * particular restriction on config. Anything value can be set here and
-     * referenced from other steps.
-     *
-     * TODO: add instance support.
-     *
-     * @param      string $name of the field
-     * @param      mixed $value
-     */
-    public function set_dataflow_var($name, $value) {
-        // Check if this field can be updated or not, e.g. if this was forced in config, it should not be updatable.
-        // TODO: implement.
-
-        $dataflow = $this->dataflow;
-        $previous = $dataflow->vars->{$name} ?? '';
-        $this->log("Setting dataflow '$name' to '$value' (from '{$previous}')");
-        $this->dataflow->set_var($name, $value);
-
-        // Persists the variable to the dataflow config.
-        // NOTE: This is skipped during a dry-run. Variables 'should' still be accessible as per normal.
-        if (!$this->isdryrun) {
-            $this->dataflow->save();
-        }
-    }
-
-    /**
-     * Sets a variable at the global plugin level
-     *
-     * Values here are - similar to the dataflow and step scope - set against a
-     * config field. This however is stored via set_config and there is no
-     * instance only support.
-     *
-     * @param      string $name of the field
-     * @param      mixed $value
-     */
-    public function set_global_var($name, $value) {
-        // Grabs the current config.
-        $vars = get_config('tool_dataflows', 'global_vars');
-        $vars = Yaml::parse($vars, Yaml::PARSE_OBJECT_FOR_MAP) ?: new \stdClass;
-
-        // Updates the field in question.
-        $previous = $vars->{$name} ?? '';
-        $vars->{$name} = $value;
-
-        // Updates the stored config.
-        $yaml = Yaml::dump(
-            (array) $vars,
-            helper::YAML_DUMP_INLINE_LEVEL,
-            helper::YAML_DUMP_INDENT_LEVEL,
-            Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK
-        );
-        $this->log("Setting global '$name' to '$value' (from '{$previous}')");
-        set_config('global_vars', $yaml, 'tool_dataflows');
-    }
-
-    /**
      * Updates the status of this engine
      *
      * This also records some metadata in the relevant objects e.g. the dataflow's state.

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -140,7 +140,7 @@ class engine {
         $this->isdryrun = $isdryrun;
         $this->automated = $automated;
 
-        $this->variables = new variables_root($dataflow);
+        $this->variables = $dataflow->get_variables_root();
 
         $this->set_status(self::STATUS_NEW);
 
@@ -185,8 +185,6 @@ class engine {
 
         // Find the flow blocks.
         $this->create_flow_caps();
-
-        $dataflow->rebuild_variables();
     }
 
     /**

--- a/classes/local/execution/engine_flow_cap.php
+++ b/classes/local/execution/engine_flow_cap.php
@@ -56,7 +56,7 @@ class engine_flow_cap extends flow_engine_step {
                     $this->set_status(engine::STATUS_FINISHED);
                 } catch (\Throwable $thrown) {
                     $this->exception = $thrown;
-                    $this->engine->abort();
+                    $this->engine->abort($thrown);
                 }
                 break;
             case self::PROCEED_STOP:

--- a/classes/local/execution/engine_step.php
+++ b/classes/local/execution/engine_step.php
@@ -199,68 +199,6 @@ abstract class engine_step {
     }
 
     /**
-     * Sets a variable, at the path provided.
-     *
-     * Currently, this will set it into the step's configuration.
-     *
-     * TODO: later this might only set it into the instance's history record,
-     * such that failed execution can be continued without creating a new 'run'.
-     * For example, set_var always goes to instance vars, set_config always
-     * updates step's config.
-     *
-     * @param  string $name or path to name of field e.g. 'some.nested.fieldname'
-     * @param  mixed $value
-     */
-    public function set_var($name, $value) {
-        // Check if this is an available field to set in the step type.
-        if (!$this->steptype->is_field_valid($name)) {
-            $stepurl = new \moodle_url('/admin/tool/dataflows/step.php', ['id' => $this->stepdef->id]);
-            throw new \moodle_exception('variablefieldnotexpected', 'tool_dataflows', $stepurl, (object) [
-                'field' => $name,
-                'steptype' => $this->steptype->get_id(),
-            ]);
-        }
-
-        // Check if this field can be updated or not, e.g. if this was forced in config, it should not be updatable.
-        // TODO: implement.
-
-        $previous = $this->stepdef->config->{$name};
-        $this->log("Setting step '$name' to '$value' (from '{$previous}')");
-        $this->stepdef->set_var($name, $value);
-
-        // Persists the variable to the dataflow step config.
-        // NOTE: This is skipped during a dry-run. Variables 'should' still be accessible as per normal.
-        if (!$this->engine->isdryrun) {
-            $this->stepdef->save();
-        }
-    }
-
-    /**
-     * Sets a variable at the dataflow level
-     *
-     * This is a proxy to the engine's implementation.
-     * TODO: add instance support.
-     *
-     * @param  string $name of the field
-     * @param  mixed $value
-     */
-    public function set_dataflow_var($name, $value) {
-        $this->engine->set_dataflow_var($name, $value);
-    }
-
-    /**
-     * Sets a variable at the global (plugin) level
-     *
-     * This is a proxy to the engine's implementation.
-     *
-     * @param  string $name of the field
-     * @param  mixed $value
-     */
-    public function set_global_var($name, $value) {
-        $this->engine->set_global_var($name, $value);
-    }
-
-    /**
      * Updates the status of this engine's step
      *
      * This also records some metadata in the relevant objects e.g. the step's state.

--- a/classes/local/execution/flow_engine_step.php
+++ b/classes/local/execution/flow_engine_step.php
@@ -75,37 +75,4 @@ class flow_engine_step extends engine_step {
         }
         return $this->status;
     }
-
-    /**
-     * Returns an array with all the variables available, with the context of the step
-     *
-     * @return  array
-     */
-    public function get_variables(): array {
-        // Config values are directly referenceable, step values go through
-        // step.fieldname, everything else is available through expressions,
-        // such as 'dataflow.id' and 'steps.mystep.name' for example.
-        $variables = $this->engine->get_variables();
-        $step = $variables['steps']->{$this->stepdef->alias};
-
-        // Pull out the config.
-        $config = $step->config ?? new \stdClass;
-
-        // Set the record as an available variable.
-        if ($this->iterator) {
-            $variables['record'] = $this->iterator->current();
-
-            // Evaluate the config again with the record context, unless the
-            // step type doesn't want to (e.g. SQL reader does it own handling).
-            $parser = new parser;
-            $parser->evaluate_recursive($config, $variables);
-        }
-
-        // We copy the contents of the step subtree into the root, to enable 'localised' access to the step variables.
-        // E.g. we can use ${{config.setting}} instead of ${{steps.first.config.setting}}.
-        return array_merge(
-            $variables,
-            (array) $step
-        );
-    }
 }

--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -207,8 +207,7 @@ class dataflow_iterator implements iterator {
             $this->step->log('Iteration ' . $this->iterationcount . ': ' . json_encode($newvalue));
         } catch (\Throwable $e) {
             $this->step->log($e->getMessage());
-            $this->step->engine->abort();
-            throw $e;
+            $this->step->engine->abort($e);
         }
 
         return $newvalue;

--- a/classes/local/execution/variables_base.php
+++ b/classes/local/execution/variables_base.php
@@ -1,0 +1,98 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\execution;
+
+/**
+ * Base class for variables objects.
+ *
+ * @package   tool_daaflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class variables_base implements \IteratorAggregate {
+    /** @var \stdClass The variables store. */
+    protected $sourcetree;
+
+    /**
+     * Make the object.
+     */
+    public function __construct() {
+        $this->sourcetree = new \stdClass();
+    }
+
+    /**
+     * Get a variable's value.
+     *
+     * @param string $name The name of the variable using dot format (e.g. dataflow.vars.abc).
+     * @return mixed The value, or null if the variable is not defined.
+     */
+    public function get(string $name) {
+        $levels = explode('.', $name);
+        $root = $this->sourcetree;
+        $child = array_shift($levels);
+        if (!isset($root->$child)) {
+            return null;
+        }
+        while (count($levels) !== 0) {
+            if ($root->$child instanceof variables_base) {
+                return $root->$child->get(implode('.', $levels));
+            }
+            $root = $root->$child;
+            $child = array_shift($levels);
+            if (!isset($root->$child)) {
+                return null;
+            }
+        }
+        return $root->$child;
+    }
+
+    /**
+     * Sets a variable in the tree.
+     *
+     * @param string $name The name of the variable in dot format, relative to this tree's root (e.g. 'config.destination').
+     * @param mixed $value.
+     */
+    public function set(string $name, $value) {
+        $levels = explode('.', $name);
+        $root = $this->sourcetree;
+        $child = array_shift($levels);
+        while (count($levels) !== 0) {
+            if (!isset($root->$child)) {
+                $root->$child = new \stdClass();
+            }
+            if ($root->$child instanceof variables_base) {
+                $root->$child->set(implode('.', $levels), $value);
+                return;
+            }
+            if (!is_object($root->$child)) {
+                throw new \moodle_exception('trying to dereference through a non-object.');
+            }
+            $root = $root->$child;
+            $child = array_shift($levels);
+        }
+        $root->$child = $value;
+    }
+
+    /**
+     * Returns an iterator over the variables' top elements.
+     */
+    public function getIterator(): \Traversable {
+        return new \ArrayIterator($this->sourcetree);
+    }
+}
+

--- a/classes/local/execution/variables_dataflow.php
+++ b/classes/local/execution/variables_dataflow.php
@@ -1,0 +1,74 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\execution;
+
+use Symfony\Component\Yaml\Yaml;
+use tool_dataflows\dataflow;
+use tool_dataflows\helper;
+use tool_dataflows\parser;
+use tool_dataflows\step;
+
+/**
+ * Class for storing and managing the variables tree for a dataflow.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class variables_dataflow extends variables_base {
+    /** @var variables_root The variable root. */
+    private $root;
+
+    /**
+     * Construct a variables object for a dataflow.
+     *
+     * @param dataflow $dataflow
+     */
+    public function __construct(dataflow $dataflow, variables_root $root) {
+        parent::__construct();
+        $this->root = $root;
+
+        // Define the structure of the dataflow variables tree.
+        $dataflowvars = $dataflow->get_export_data(false);
+        unset($dataflowvars->steps);
+        $this->sourcetree->name = $dataflow->name;
+        $this->sourcetree->vars = $dataflow->get_raw_vars();
+        $this->sourcetree->config = new \stdClass();
+        $this->sourcetree->config->enabled = $dataflow->enabled;
+        $this->sourcetree->config->concurrencyenabled = $dataflow->concurrencyenabled;
+        $this->sourcetree->states = new \stdClass();
+        // Initialise all the possible states.
+        $this->sourcetree->states = (object) array_combine(
+            // All the labels.
+            engine::STATUS_LABELS,
+            // Filled with null.
+            array_fill(0, count(engine::STATUS_LABELS), null)
+        );
+    }
+
+    /**
+     * Sets a variable in the tree.
+     *
+     * @param string $name The name of the variable in dot format, relative to this tree's root (e.g. 'config.destination').
+     * @param mixed $value.
+     */
+    public function set(string $name, $value) {
+        parent::set($name, $value);
+        $this->root->invalidate();
+    }
+}

--- a/classes/local/execution/variables_dataflow.php
+++ b/classes/local/execution/variables_dataflow.php
@@ -71,4 +71,14 @@ class variables_dataflow extends variables_base {
         parent::set($name, $value);
         $this->root->invalidate();
     }
+
+    /**
+     * Get a variable's value with expressions resolved.
+     *
+     * @param string $name The name of the variable using dot format, relative to the dataflow root. (e.g. vars.abc).
+     * @return mixed The value, or null if the variable is not defined.
+     */
+    public function get_resolved(string $name) {
+        return $this->root->get_resolved("dataflow.$name");
+    }
 }

--- a/classes/local/execution/variables_dataflow.php
+++ b/classes/local/execution/variables_dataflow.php
@@ -44,10 +44,9 @@ class variables_dataflow extends variables_base {
         $this->root = $root;
 
         // Define the structure of the dataflow variables tree.
-        $dataflowvars = $dataflow->get_export_data(false);
-        unset($dataflowvars->steps);
+        $this->sourcetree->id = $dataflow->id;
         $this->sourcetree->name = $dataflow->name;
-        $this->sourcetree->vars = $dataflow->get_raw_vars();
+        $this->sourcetree->vars = $dataflow->get('vars');
         $this->sourcetree->config = new \stdClass();
         $this->sourcetree->config->enabled = $dataflow->enabled;
         $this->sourcetree->config->concurrencyenabled = $dataflow->concurrencyenabled;

--- a/classes/local/execution/variables_root.php
+++ b/classes/local/execution/variables_root.php
@@ -126,7 +126,18 @@ class variables_root extends variables_base {
      */
     public function evaluate(string $expression): string {
         $parser = new parser();
-        return $parser->evaluate_or_fail($expression, (array) $this->get_tree());
+        return $parser->evaluate($expression, (array) $this->get_tree());
+    }
+
+    /**
+     * Evaluate an expression against the resolved variables, utilising a callback for failure..
+     *
+     * @param string $expression
+     * @return string
+     */
+    public function evaluate_or_fail(string $expression, ?callable $callback = null): string {
+        $parser = new parser();
+        return $parser->evaluate_or_fail($expression, (array) $this->get_tree(), $callback);
     }
 
     /**

--- a/classes/local/execution/variables_root.php
+++ b/classes/local/execution/variables_root.php
@@ -1,0 +1,236 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\execution;
+
+use Symfony\Component\Yaml\Yaml;
+use tool_dataflows\dataflow;
+use tool_dataflows\helper;
+use tool_dataflows\parser;
+use tool_dataflows\step;
+
+/**
+ * Class for storing and managing the whole variables tree for a dataflow execution.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class variables_root extends variables_base {
+    /** Used to detect cyclic dependencies. */
+    private const PLACEHOLDER = '__PLACEHOLDER__';
+    /** Limit to number of repeats of evaluating the tree. */
+    private const REPEAT_LIMIT = 100;
+
+    /** @var dataflow The dataflow this variable object is for. */
+    private $dataflow;
+
+    /** @var object The current state of the variables tree with expressions evaluated. */
+    private $tree;
+
+    /** @var string|null Localised step. */
+    private $localstep = null;
+    /** @var bool Reconstruct the tree on next read. */
+    private $isvalid = false;
+
+    /**
+     * Construct a variables object for a dataflow.
+     *
+     * @param dataflow $dataflow
+     */
+    public function __construct(dataflow $dataflow) {
+        parent::__construct();
+
+        // Global variables. These should be immutable.
+        $globalvars = new \stdClass();
+        $globalvars->cfg = helper::get_cfg_vars();
+        $globalvars->vars = Yaml::parse(get_config('tool_dataflows', 'global_vars'), Yaml::PARSE_OBJECT_FOR_MAP)
+                ?? new \stdClass();
+        $this->sourcetree->global = $globalvars;
+
+        // The variables for dataflow.
+        $this->sourcetree->dataflow = new variables_dataflow($dataflow, $this);
+
+        // The variables for each step.
+        $this->sourcetree->steps = new \stdClass();
+        foreach ($dataflow->steps as $stepdef) {
+            $this->sourcetree->steps->{$stepdef->alias} = new variables_step($stepdef, $this);
+        }
+    }
+
+    /**
+     * Gets the dataflow variables object.
+     *
+     * @return variables_dataflow
+     */
+    public function get_dataflow_variables(): variables_dataflow {
+        return $this->sourcetree->dataflow;
+    }
+
+    /**
+     * Get the step variables object.
+     *
+     * @param string $alias
+     * @return variables_step
+     */
+    public function get_step_variables(string $alias): variables_step {
+        return $this->sourcetree->steps->{$alias};
+    }
+
+    /**
+     * Makes a step to be localised. This allows its subtree to be accessed relatively.
+     * E.g. Set alias to 'xyz', and 'steps.xyz.vars.someval' can now be accessed as 'vars.someval'.
+     * Set to null to remove localisation.
+     *
+     * @param string|null $alias
+     */
+    public function localise(?string $alias = null) {
+        $this->localstep = $alias;
+        $this->isvalid = false;
+    }
+
+    /**
+     * Get the variables tree with expression resolution.
+     *
+     * @return object
+     */
+    public function get_tree(): object {
+        if (!$this->isvalid) {
+            $this->reconstruct();
+        }
+        return $this->tree;
+    }
+
+    /**
+     * Get a variable's value with expressions resolved.
+     *
+     * @param string $name The name of the variable using dot format (e.g. dataflow.vars.abc).
+     * @return mixed The value, or null if the variable is not defined.
+     */
+    public function get_resolved(string $name) {
+        if (!$this->isvalid) {
+            $this->reconstruct();
+        }
+        $levels = explode('.', $name);
+        $root = $this->tree;
+        $child = array_shift($levels);
+        if (!isset($root->$child)) {
+            return null;
+        }
+        while (count($levels) !== 0) {
+            $root = $root->$child;
+            $child = array_shift($levels);
+            if (!isset($root->$child)) {
+                return null;
+            }
+        }
+        return $root->$child;
+    }
+
+    /**
+     * Reconstructs the tree.
+     */
+    public function reconstruct() {
+        // Make a clean copy of the variable definitions.
+        $this->tree = new \stdClass();
+        $this->clone($this->tree, $this->sourcetree);
+
+        // Go through the tree and resolve expressions. Do this repeatedly to catch expressions that resolve into expressions.
+        for ($i = 0; $i < self::REPEAT_LIMIT; ++$i) {
+            if (!$this->tree_walk('', $this->tree)) {
+                break;
+            }
+        }
+        $this->isvalid = true;
+    }
+
+    /**
+     * Copy the object over.
+     *
+     * @param object $newtree
+     * @param object $oldtree
+     */
+    private function clone(object $newtree, object $oldtree) {
+        foreach ($oldtree as $key => $value) {
+            if (is_object($value)) {
+                $newtree->$key = new \stdClass();
+                $this->clone($newtree->$key, $value);
+            } else {
+                $newtree->$key = $value;
+            }
+        }
+    }
+
+    /**
+     * Walk through the tree, resolving expressions.
+     *
+     * @param string $name
+     * @param object $tree
+     * @return bool
+     */
+    private function tree_walk(string $name, object $tree): bool {
+        $foundexpression = false;
+        foreach ($tree as $key => &$value) {
+            if (is_object($value)) {
+                $foundexpression |= $this->tree_walk("$name.$key", $value);
+            } else if (is_string($value)) {
+                $foundexpression |= $this->resolve_expression("$name.$key", $value);
+            }
+        }
+        return $foundexpression;
+    }
+
+    /**
+     * Resolves the expressions in the value.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return bool
+     * @throws \moodle_exception
+     */
+    private function resolve_expression(string $name, &$value): bool {
+        $parser = new parser();
+
+        if (!$parser->has_expression($value)) {
+            return false;
+        }
+
+        // Apply localising.
+        $tree = $this->localstep ? array_merge((array) $this->tree, (array) $this->tree->steps->{$this->alias}) : (array) $this->tree;
+
+        $resolved = $parser->evaluate($value, $tree);
+        if ($resolved === self::PLACEHOLDER) {
+            throw new \moodle_exception(
+                'recursiveexpressiondetected',
+                'tool_dataflows',
+                '',
+                ltrim($name, '.')
+            );
+        }
+        if (isset($resolved)) {
+            $value = $resolved;
+        }
+        return true;
+    }
+
+    /**
+     * Invalidates the tree, ensuring it will get rebuilt.
+     */
+    public function invalidate() {
+        $this->isvalid = false;
+    }
+}

--- a/classes/local/execution/variables_step.php
+++ b/classes/local/execution/variables_step.php
@@ -30,6 +30,9 @@ class variables_step extends variables_base {
     /** @var variables_root The root variables object. */
     private $root;
 
+    /** @var string Name of the node. */
+    private $name;
+
     /**
      * Constructs the object, setting up the structure.
      *
@@ -39,6 +42,7 @@ class variables_step extends variables_base {
     public function __construct(step $stepdef, variables_root $root) {
         parent::__construct();
         $this->root = $root;
+        $this->name = $stepdef->alias;
 
         // Define the structure of the variables.
         $this->sourcetree->name = $stepdef->name;
@@ -59,6 +63,15 @@ class variables_step extends variables_base {
     }
 
     /**
+     * Localise this step.
+     *
+     * @param bool $set
+     */
+    public function localise(bool $set = true) {
+        $this->root->localise($set ? $this->name : null);
+    }
+
+    /**
      * Sets a variable in the tree.
      *
      * @param string $name The name of the variable in dot format, relative to this tree's root (e.g. 'config.destination').
@@ -67,5 +80,15 @@ class variables_step extends variables_base {
     public function set(string $name, $value) {
         parent::set($name, $value);
         $this->root->invalidate();
+    }
+
+    /**
+     * Get a variable's value with expressions resolved.
+     *
+     * @param string $name The name of the variable using dot format, relative to the step root. (e.g. vars.abc).
+     * @return mixed The value, or null if the variable is not defined.
+     */
+    public function get_resolved(string $name) {
+        return $this->root->get_resolved("steps.$this->name.$name");
     }
 }

--- a/classes/local/execution/variables_step.php
+++ b/classes/local/execution/variables_step.php
@@ -45,13 +45,14 @@ class variables_step extends variables_base {
         $this->name = $stepdef->alias;
 
         // Define the structure of the variables.
+        $this->sourcetree->id = $stepdef->id;
         $this->sourcetree->name = $stepdef->name;
         $this->sourcetree->alias = $stepdef->alias;
         $this->sourcetree->description = $stepdef->description;
         $this->sourcetree->depends_on = $stepdef->get_dependencies_cleaned();
         $this->sourcetree->type = $stepdef->type;
-        $this->sourcetree->config = $stepdef->get_raw_config();
-        $this->sourcetree->vars = $stepdef->get_raw_vars();
+        $this->sourcetree->config = $stepdef->get('config');
+        $this->sourcetree->vars = $stepdef->get('vars');
         // Initialise all the possible states.
         $this->sourcetree->states = (object) array_combine(
             // All the labels.

--- a/classes/local/execution/variables_step.php
+++ b/classes/local/execution/variables_step.php
@@ -1,0 +1,71 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\execution;
+
+use tool_dataflows\step;
+
+/**
+ * Manager for step variables.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class variables_step extends variables_base {
+    /** @var variables_root The root variables object. */
+    private $root;
+
+    /**
+     * Constructs the object, setting up the structure.
+     *
+     * @param step $stepdef
+     * @param variables_root $root
+     */
+    public function __construct(step $stepdef, variables_root $root) {
+        parent::__construct();
+        $this->root = $root;
+
+        // Define the structure of the variables.
+        $this->sourcetree->name = $stepdef->name;
+        $this->sourcetree->alias = $stepdef->alias;
+        $this->sourcetree->description = $stepdef->description;
+        $this->sourcetree->depends_on = $stepdef->get_dependencies_cleaned();
+        $this->sourcetree->type = $stepdef->type;
+        $this->sourcetree->config = $stepdef->get_raw_config();
+        $this->sourcetree->vars = $stepdef->get_raw_vars();
+        // Initialise all the possible states.
+        $this->sourcetree->states = (object) array_combine(
+            // All the labels.
+            engine::STATUS_LABELS,
+            // Filled with null.
+            array_fill(0, count(engine::STATUS_LABELS), null)
+        );
+        // TODO outputs?
+    }
+
+    /**
+     * Sets a variable in the tree.
+     *
+     * @param string $name The name of the variable in dot format, relative to this tree's root (e.g. 'config.destination').
+     * @param mixed $value.
+     */
+    public function set(string $name, $value) {
+        parent::set($name, $value);
+        $this->root->invalidate();
+    }
+}

--- a/classes/local/step/abort_trait.php
+++ b/classes/local/step/abort_trait.php
@@ -39,17 +39,17 @@ trait abort_trait {
      * @return mixed
      */
     public function execute($input = null) {
-        $config = $this->get_config();
+        $condition = $this->get_variables()->get_resolved('config.condition');
 
         // If a condition was set, it should not abort if the result is false. be evaluated and abort if 'true'.
-        if ($config->condition === false) {
+        if ($condition === false) {
             return $input;
         }
 
         // If the condition was set, print out the results of the expression so it's obvious what it had evaluated to.
-        if ($config->condition !== '') {
-            $rawconfig = $this->get_raw_config();
-            $strresult = var_export($config->condition, true);
+        if ($condition !== '') {
+            $rawconfig = $this->get_config();
+            $strresult = var_export($condition, true);
             $this->log("Aborting dataflow due to the expression returning '{$strresult}': {$rawconfig->condition}");
         }
 

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -39,9 +39,6 @@ abstract class base_step {
     /** @var step The step definition use to create the engine step. */
     protected $stepdef = null;
 
-    /** @var array of variables exposed for use from this step. */
-    protected $variables = [];
-
     /**
      * This is autopopulated by the dataflows manager.
      *
@@ -105,32 +102,6 @@ abstract class base_step {
      */
     public function define_outputs(): array {
         return [];
-    }
-
-    /**
-     * Resolves and sets variables for the 'vars' subtree.
-     */
-    public function prepare_vars() {
-        $vars = $this->stepdef->get_raw_vars();
-        if (!helper::obj_empty($vars)) {
-            $parser = new parser();
-            $enginestep = $this->get_engine_step();
-            if ($enginestep) {
-                $variables = $enginestep->get_variables();
-            } else {
-                $variables = $this->stepdef->variables;
-            }
-            $vars = $parser->evaluate_recursive($vars, $variables);
-            $this->stepdef->set_varsvariables($vars);
-
-            $yaml = Yaml::dump(
-                (array) $vars,
-                helper::YAML_DUMP_INLINE_LEVEL,
-                helper::YAML_DUMP_INDENT_LEVEL,
-                Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK
-            );
-            $this->enginestep->log("Debug: Setting step defined output vars:\n" . trim($yaml));
-        }
     }
 
     /**
@@ -623,6 +594,7 @@ abstract class base_step {
      * @return  \stdClass configuration object
      */
     protected function get_config(): \stdClass {
+        // TODO Should change name to get_resolved_config()
         return $this->enginestep->get_variables()->get_resolved("config");
     }
 
@@ -634,7 +606,8 @@ abstract class base_step {
      * @return  \stdClass configuration object
      */
     protected function get_raw_config(): \stdClass {
-        return $this->stepdef->get_raw_config();
+        // TODO Shoudl change to get_config.
+        return $this->stepdef->config;
     }
 
     /**

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -20,7 +20,7 @@ use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\helper;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\engine_step;
-use tool_dataflows\parser;
+use tool_dataflows\local\execution\variables_step;
 use tool_dataflows\step;
 
 /**
@@ -555,8 +555,8 @@ abstract class base_step {
      * @param   string $name
      * @param   mixed $value
      */
-    public function set_variables(string $name, $value) {
-        $this->enginestep->get_variables()->set($name, $value);
+    public function set_variable(string $name, $value) {
+        $this->get_variables()->set($name, $value);
     }
 
     /**
@@ -593,9 +593,9 @@ abstract class base_step {
      *
      * @return  \stdClass configuration object
      */
-    protected function get_config(): \stdClass {
+    protected function get_resolved_config(): \stdClass {
         // TODO Should change name to get_resolved_config()
-        return $this->enginestep->get_variables()->get_resolved("config");
+        return $this->get_variables()->get_resolved("config");
     }
 
     /**
@@ -605,9 +605,17 @@ abstract class base_step {
      *
      * @return  \stdClass configuration object
      */
-    protected function get_raw_config(): \stdClass {
-        // TODO Shoudl change to get_config.
+    protected function get_config(): \stdClass {
         return $this->stepdef->config;
+    }
+
+    /**
+     * Get the local step variables
+     *
+     * @return variables_step
+     */
+    protected function get_variables(): variables_step {
+        return $this->enginestep->get_variables();
     }
 
     /**
@@ -636,7 +644,7 @@ abstract class base_step {
      * Log the current vars.
      */
     public function log_vars() {
-        $vars = $this->enginestep->get_variables()->get_resolved("vars");
+        $vars = $this->get_variables()->get_resolved("vars");
         if (!is_null($vars) && !helper::obj_empty($vars)) {
             $yaml = Yaml::dump(
                 (array) $vars,

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -594,7 +594,6 @@ abstract class base_step {
      * @return  \stdClass configuration object
      */
     protected function get_resolved_config(): \stdClass {
-        // TODO Should change name to get_resolved_config()
         return $this->get_variables()->get_resolved("config");
     }
 
@@ -606,7 +605,7 @@ abstract class base_step {
      * @return  \stdClass configuration object
      */
     protected function get_config(): \stdClass {
-        return $this->stepdef->config;
+        return $this->stepdef->get('config');
     }
 
     /**
@@ -615,7 +614,10 @@ abstract class base_step {
      * @return variables_step
      */
     protected function get_variables(): variables_step {
-        return $this->enginestep->get_variables();
+        if (is_null($this->stepdef)) {
+            throw new \moodle_exception('no_variables', 'tool_dataflows');
+        }
+        return $this->stepdef->get_variables();
     }
 
     /**

--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -48,7 +48,7 @@ class connector_curl extends connector_step {
      */
     public function has_side_effect(): bool {
         if (isset($this->stepdef)) {
-            $config = $this->stepdef->config;
+            $config = $this->get_resolved_config();
 
             // Destination is outside of scratch directory.
             if (!(empty($config->destination) || helper::path_is_relative($config->destination))) {
@@ -194,7 +194,7 @@ class connector_curl extends connector_step {
      * @return true|array Will return true or an array of errors.
      */
     public function validate_for_run() {
-        $config = $this->stepdef->config;
+        $config = $this->get_resolved_config();
 
         if (!empty($config->destination)) {
             $error = helper::path_validate($config->destination);
@@ -216,7 +216,7 @@ class connector_curl extends connector_step {
      */
     public function execute($input = null) {
         // Get variables.
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
         $method = $config->method;
 
         $this->enginestep->log($config->curl);
@@ -268,10 +268,10 @@ class connector_curl extends connector_step {
 
         // Log the raw curl command.
         $this->enginestep->log($dbgcommand);
-        $this->set_variables('dbgcommand', $dbgcommand);
+        $this->set_variable('dbgcommand', $dbgcommand);
 
         // We do not need to go any further if curl is not going to be called.
-        if ($this->enginestep->engine->isdryrun && $this->has_side_effect()) {
+        if ($this->is_dry_run() && $this->has_side_effect()) {
             return true;
         }
 
@@ -312,7 +312,7 @@ class connector_curl extends connector_step {
 
         // TODO: It would be good to define and list any fixed but exposed
         // fields which the user can use and map to on the edit page.
-        $this->set_variables('response', (object) [
+        $this->set_variable('response', (object) [
             'result' => $result,
             'info' => (object) $info,
             'destination' => $destination,

--- a/classes/local/step/connector_debug_file_display.php
+++ b/classes/local/step/connector_debug_file_display.php
@@ -37,7 +37,7 @@ class connector_debug_file_display extends connector_step {
      * @return mixed
      */
     public function execute($input = null) {
-        $config = $this->enginestep->stepdef->config;
+        $config = $this->get_resolved_config();
 
         $streamname = $this->enginestep->engine->resolve_path($config->streamname);
         $content = file_get_contents($streamname);

--- a/classes/local/step/connector_directory_file_count.php
+++ b/classes/local/step/connector_directory_file_count.php
@@ -58,12 +58,12 @@ class connector_directory_file_count extends connector_step {
      * @return mixed
      */
     public function execute($input = null) {
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
 
         $path = $this->enginestep->engine->resolve_path($config->path);
         $count = $this->run($path);
         $this->log("Found {$count} files");
-        $this->set_variables('result', $count);
+        $this->set_variable('result', $count);
 
         return $input;
     }

--- a/classes/local/step/connector_email.php
+++ b/classes/local/step/connector_email.php
@@ -65,12 +65,12 @@ class connector_email extends connector_step {
     public function execute($input = null) {
 
         // Do not execute operations during a dry run.
-        if ($this->enginestep->engine->isdryrun) {
+        if ($this->is_dry_run()) {
             $this->enginestep->log('Do not send email notification as this is a dry run.');
             return true;
         }
 
-        $config = $this->enginestep->stepdef->config;
+        $config = $this->get_resolved_config();
 
         $toemail = $config->to;
 

--- a/classes/local/step/connector_file_exists.php
+++ b/classes/local/step/connector_file_exists.php
@@ -58,11 +58,11 @@ class connector_file_exists extends connector_step {
      * @return mixed
      */
     public function execute($input = null) {
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
 
         $path = $this->enginestep->engine->resolve_path($config->path);
         $exists = file_exists($path);
-        $this->set_variables('exists', $exists);
+        $this->set_variable('exists', $exists);
 
         return true;
     }

--- a/classes/local/step/connector_sns_notify.php
+++ b/classes/local/step/connector_sns_notify.php
@@ -85,13 +85,13 @@ class connector_sns_notify extends connector_step {
         }
 
         // Do not execute operations during a dry run.
-        if ($this->enginestep->engine->isdryrun) {
+        if ($this->is_dry_run()) {
             $this->enginestep->log('Do not send SNS notification as this is a dry run.');
             return true;
         }
 
         // Create the client.
-        $config = $this->enginestep->stepdef->config;
+        $config = $this->get_resolved_config();
         $connectionoptions = [
             'version' => 'latest',
             'region' => $config->region,

--- a/classes/local/step/connector_wait.php
+++ b/classes/local/step/connector_wait.php
@@ -59,7 +59,7 @@ class connector_wait extends connector_step {
      * @return mixed
      */
     public function execute($input = null) {
-        $timesec = $this->stepdef->config->timesec;
+        $timesec = $this->get_resolved_config()->timesec;
         if (!is_int($timesec) && !(is_string($timesec) && ctype_digit($timesec))) {
             throw new \moodle_exception('connector_wait:not_integer', 'tool_dataflows', '', $timesec);
         }

--- a/classes/local/step/flow_copy_file.php
+++ b/classes/local/step/flow_copy_file.php
@@ -71,7 +71,7 @@ class flow_copy_file extends flow_step {
     public function execute($input = null) {
         global $CFG;
 
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
         $from = $this->enginestep->engine->resolve_path($config->from);
         $to = $this->enginestep->engine->resolve_path($config->to);
 
@@ -128,7 +128,7 @@ class flow_copy_file extends flow_step {
      * @return true|array Will return true or an array of errors.
      */
     public function validate_for_run() {
-        $config = $this->stepdef->config;
+        $config = $this->get_resolved_config();
 
         $errors = [];
 

--- a/classes/local/step/flow_email.php
+++ b/classes/local/step/flow_email.php
@@ -67,12 +67,12 @@ class flow_email extends flow_step {
     public function execute($input = null) {
 
         // Do not execute operations during a dry run.
-        if ($this->enginestep->engine->isdryrun) {
+        if ($this->is_dry_run()) {
             $this->enginestep->log('Do not send email notification as this is a dry run.');
             return true;
         }
 
-        $config = $this->enginestep->stepdef->config;
+        $config = $this->get_resolved_config();
 
         $parser = new parser();
         $parser->evaluate_recursive($config, ['data' => $input]);

--- a/classes/local/step/flow_logic_switch.php
+++ b/classes/local/step/flow_logic_switch.php
@@ -226,7 +226,7 @@ class flow_logic_switch extends flow_logic_step {
                     $parser = new parser;
                     $casefailures = 0;
                     foreach ($this->cases as $caseindex => $case) {
-                        $result = (bool) $caller->step->engine->get_variables()->evaluate('${{ ' . $case . ' }}');
+                        $result = (bool) $caller->step->engine->get_variables()->evaluate_or_fail('${{ ' . $case . ' }}');
 
                         // If there was a passing expression, break the loop.
                         if ($result === true) {

--- a/classes/local/step/flow_web_service.php
+++ b/classes/local/step/flow_web_service.php
@@ -178,7 +178,7 @@ EOF;
         $currentoutput = $OUTPUT;
         $outertransaction = $DB->is_transaction_started();
 
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
         $isdryrun = $this->is_dry_run();
         $userid = $DB->get_field('user', 'id', ['username' => $config->user]);
         $user = core_user::get_user($userid);
@@ -236,7 +236,7 @@ EOF;
             }
             // Success - store any desired value for subsequent steps.
             // Output will then evaluate result.
-            $this->set_variables('result', $response['data']);
+            $this->set_variable('result', $response['data']);
         }
         return $input;
     }

--- a/classes/local/step/hash_file_trait.php
+++ b/classes/local/step/hash_file_trait.php
@@ -73,11 +73,11 @@ trait hash_file_trait {
      * @return mixed
      */
     public function execute($input = null) {
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
         $filename = $this->enginestep->engine->resolve_path($config->path);
         $hash = hash_file($config->algorithm, $filename);
         $this->log("The file hash value: {$hash}");
-        $this->set_variables('hash', $hash);
+        $this->set_variable('hash', $hash);
         return $input;
     }
 
@@ -87,7 +87,7 @@ trait hash_file_trait {
      * @return true|array Will return true or an array of errors.
      */
     public function validate_for_run() {
-        $config = $this->stepdef->config;
+        $config = $this->get_resolved_config();
 
         $errors = [];
 

--- a/classes/local/step/reader_csv.php
+++ b/classes/local/step/reader_csv.php
@@ -60,7 +60,7 @@ class reader_csv extends reader_step {
      */
     public function csv_contents_generator() {
         $maxlinelength = 1000;
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
         $strheaders = $config->headers;
         $path = $this->enginestep->engine->resolve_path($config->path);
 

--- a/classes/local/step/reader_json.php
+++ b/classes/local/step/reader_json.php
@@ -69,7 +69,7 @@ class reader_json extends reader_step {
      * @throws \moodle_exception
      */
     protected function parse_json() {
-        $config = $this->enginestep->stepdef->config;
+        $config = $this->get_resolved_config();
         $jsonstring = $this->get_json_string($config->pathtojson);
 
         $decodedjson = json_decode($jsonstring);

--- a/classes/local/step/s3_trait.php
+++ b/classes/local/step/s3_trait.php
@@ -41,7 +41,7 @@ trait s3_trait {
      */
     public function has_side_effect(): bool {
         if (isset($this->stepdef)) {
-            $config = $this->stepdef->config;
+            $config = $this->get_resolved_config();
             return !helper::path_is_relative($config->target);
         }
         return true;
@@ -108,7 +108,7 @@ trait s3_trait {
             return $input;
         }
 
-        $config = $this->get_config();
+        $config = $this->get_resolved_config();
         $connectionoptions = [
             'version' => 'latest',
             'region' => $config->region,
@@ -142,7 +142,7 @@ trait s3_trait {
         }
 
         // Do not execute s3 operations during a dry run.
-        if ($this->enginestep->engine->isdryrun) {
+        if ($this->is_dry_run()) {
             $this->enginestep->log("Skipping copy to '{$target}' as this is a dry run.");
             return $input;
         }
@@ -269,7 +269,7 @@ trait s3_trait {
      * @return true|array Will return true or an array of errors.
      */
     public function validate_for_run() {
-        $config = $this->stepdef->config;
+        $config = $this->get_resolved_config();
 
         $errors = [];
 

--- a/classes/step.php
+++ b/classes/step.php
@@ -629,20 +629,9 @@ class step extends persistent {
         }
 
         // Conditionally export the dependencies (depends_on) if set.
-        $dependencies = $this->dependencies();
-        if (!empty($dependencies)) {
-            // Since this field can be a single string or an array of aliases, it should be checked beforehand.
-            $aliases = array_map(function ($dependency) {
-                if (isset($dependency->position)) {
-                    return $dependency->alias . self::DEPENDS_ON_POSITION_SPLITTER . $dependency->position;
-                }
-                return $dependency->alias;
-            }, $dependencies);
-
-            // Simplify into a single value if there is only a single entry.
-            $aliases = isset($aliases[1]) ? $aliases : reset($aliases);
-
-            $yaml['depends_on'] = $aliases;
+        $dependencies = $this->get_dependencies_cleaned();
+        if (!is_null($dependencies)) {
+            $yaml['depends_on'] = $dependencies;
         }
 
         // Resort the order of exported fields for consistency.
@@ -658,6 +647,30 @@ class step extends persistent {
         $yaml = array_replace($commonkeys, $yaml);
 
         return $yaml;
+    }
+
+    /**
+     * Get dependencies adjusted for dependency positions..
+     *
+     * @return array|false|mixed|string|string[]|null
+     */
+    public function get_dependencies_cleaned() {
+        $dependencies = $this->dependencies();
+        if (!empty($dependencies)) {
+            // Since this field can be a single string or an array of aliases, it should be checked beforehand.
+            $aliases = array_map(function ($dependency) {
+                if (isset($dependency->position)) {
+                    return $dependency->alias . self::DEPENDS_ON_POSITION_SPLITTER . $dependency->position;
+                }
+                return $dependency->alias;
+            }, $dependencies);
+
+            // Simplify into a single value if there is only a single entry.
+            $aliases = isset($aliases[1]) ? $aliases : reset($aliases);
+
+            return $aliases;
+        }
+        return null;
     }
 
     /**

--- a/classes/step.php
+++ b/classes/step.php
@@ -16,6 +16,7 @@
 
 namespace tool_dataflows;
 
+use tool_dataflows\local\execution\variables_step;
 use tool_dataflows\local\step\base_step;
 use core\persistent;
 use moodle_exception;
@@ -86,6 +87,15 @@ class step extends persistent {
     }
 
     /**
+     * Get the variables for this step.
+     *
+     * @return variables_step
+     */
+    public function get_variables(): variables_step {
+        return $this->get_dataflow()->get_variables_root()->get_step_variables($this->alias);
+    }
+
+    /**
      * Magic getter - which allows the user to get values directly instead of via ->get('name')
      *
      * @param      string $name of the property to get
@@ -131,15 +141,6 @@ class step extends persistent {
     }
 
     /**
-     * Returns vars without resolving expressions.
-     *
-     * @return \stdClass
-     */
-    public function get_raw_vars(): \stdClass {
-        return $this->get_vars();
-    }
-
-    /**
      * Validate the 'vars' field.
      *
      * @param string $vars
@@ -156,7 +157,7 @@ class step extends persistent {
      */
     public function get_dataflow(): dataflow {
         if (!isset($this->dataflow)) {
-            $dataflow = new dataflow($this->dataflowid);
+            $dataflow = dataflow::get_dataflow($this->dataflowid);
             $this->set_dataflow($dataflow);
         }
         return $this->dataflow;

--- a/classes/step.php
+++ b/classes/step.php
@@ -55,18 +55,6 @@ class step extends persistent {
     /** @var array array for lazy loading step dependants */
     private $dependents = null;
 
-    /** @var \stdClass of engine step states and timestamps */
-    private $states;
-
-    /** @var \stdClass keep track of any outputs, exposed by the user for each step */
-    private $outputs;
-
-    /** @var \stdClass Variables to set which will go in the step's root subtree. */
-    private $rootvariables;
-
-    /** @var \stdClass Variables to set which will go in the step's vars subtree. */
-    private $varsvariables;
-
     /**
      * When initialising the persistent, ensure some internal fields have been set up.
      *
@@ -74,43 +62,6 @@ class step extends persistent {
      */
     public function __construct(...$args) {
         parent::__construct(...$args);
-
-        // Ensure all states can be referenced, defaulting them to null.
-        $this->states = (object) array_combine(
-            // All the labels.
-            engine::STATUS_LABELS,
-            // Filled with null.
-            array_fill(0, count(engine::STATUS_LABELS), null)
-        );
-    }
-
-    /**
-     * Returns the states and their timestamps for this step
-     *
-     * @return  \stdClass
-     */
-    public function get_states(): \stdClass {
-        return $this->states;
-    }
-
-    /**
-     * Returns the step's outputs
-     *
-     * @return  \stdClass
-     */
-    public function get_outputs(): \stdClass {
-        return $this->outputs ?? new \stdClass;
-    }
-
-    /**
-     * Updates the timestamp for a particular state that is stored locally on the instance
-     *
-     * @param  int $state a status constant from the engine class
-     * @param  float $timestamp typically from a microtime(true) call
-     */
-    public function set_state_timestamp(int $state, float $timestamp) {
-        $label = engine::STATUS_LABELS[$state];
-        $this->states->{$label} = $timestamp;
     }
 
     /**
@@ -164,44 +115,16 @@ class step extends persistent {
     }
 
     /**
-     * Returns the variables available for this step
+     * Returns the user defined variables to be placed under the step's 'vars' subtree.
      *
-     * @return  array of variables
-     */
-    public function get_variables(): array {
-        $dataflow = $this->get_dataflow();
-        return $dataflow->variables;
-    }
-
-    /**
-     * Returns the variables stored under the step's 'vars' subtree.
-     * @param bool $expressions
      * @return \stdClass
      * @throws \coding_exception
      */
-    protected function get_vars(bool $expressions = true): \stdClass {
+    protected function get_vars(): \stdClass {
         $vars = Yaml::parse($this->raw_get('vars'), Yaml::PARSE_OBJECT_FOR_MAP);
 
         if (empty($vars)) {
             return new \stdClass();
-        }
-
-        // Normally expressions are parsed when evaluating the statement, for use in a dataflow run.
-        if ($expressions) {
-            $steptype = $this->get_steptype();
-
-            // Get variables, based on whether the engine is running or is idle.
-            $enginestep = $steptype->get_engine_step();
-            if ($enginestep) {
-                $variables = $enginestep->get_variables();
-            } else {
-                $variables = $this->variables;
-            }
-
-            if (isset($vars)) {
-                $parser = new parser();
-                $vars = $parser->evaluate_recursive($vars, $variables);
-            }
         }
 
         return $vars;
@@ -213,7 +136,7 @@ class step extends persistent {
      * @return \stdClass
      */
     public function get_raw_vars(): \stdClass {
-        return $this->get_vars(false);
+        return $this->get_vars();
     }
 
     /**
@@ -287,11 +210,9 @@ class step extends persistent {
      * Return the configuration of the dataflow, parsed such that any
      * expressions are evaluated at this point in time.
      *
-     * @param   bool $expressions whether or not to parse expressions when returning the config
-     * @param   bool $redacted Will redact secret values if true
      * @return  \stdClass configuration object
      */
-    protected function get_config($expressions = true, bool $redacted = false): \stdClass {
+    protected function get_config(): \stdClass {
         $rawconfig = $this->raw_get('config');
         $yaml = $rawconfig;
         if (gettype($rawconfig) === 'string') {
@@ -302,44 +223,19 @@ class step extends persistent {
             return new \stdClass();
         }
 
-        $steptype = $this->get_steptype();
-
-        // Ensure the secret service gets involved to redact any information required.
-        if ($redacted && isset($steptype)) {
-            $secretservice = new secret_service;
-            $yaml = $secretservice->redact_fields($yaml, $steptype->get_secret_fields());
-        }
-
-        // Normally expressions are parsed when evaluating the statement, for use in a dataflow run.
-        if ($expressions) {
-            // Get variables, based on whether the engine is running or is idle.
-            $enginestep = $steptype->get_engine_step();
-            if ($enginestep) {
-                $variables = $enginestep->get_variables();
-            } else {
-                $variables = $this->variables;
-            }
-
-            // Prepare this as a php object (stdClass), as it makes expressions easier to write.
-            if (isset($yaml)) {
-                $parser = new parser();
-                $yaml = $parser->evaluate_recursive($yaml, $variables);
-            }
-
-            // Sets it to the parsed results.
-            $variables['steps']->{$this->alias}->config = $yaml;
-        }
-
         return $yaml;
     }
 
-    /**
-     * Return the raw config without parsing of expressions
-     *
-     * @return  \stdClass
-     */
-    public function get_raw_config(): \stdClass {
-        return $this->get_config(false);
+    public function get_redacted_config(): \stdClass {
+        $config = $this->get_config();
+        $steptype = $this->get_steptype();
+
+        // Ensure the secret service gets involved to redact any information required.
+        if (isset($steptype)) {
+            $secretservice = new secret_service;
+            $config = $secretservice->redact_fields($config, $steptype->get_secret_fields());
+        }
+        return $config;
     }
 
     /**
@@ -623,7 +519,7 @@ class step extends persistent {
         }
 
         // Conditionally export the configuration if it has content.
-        $config = (array) $this->get_redacted_config(false);
+        $config = (array) $this->get_redacted_config();
         if (!empty($config)) {
             $yaml['config'] = $config;
         }
@@ -1021,6 +917,7 @@ class step extends persistent {
      * @param  mixed $value
      */
     public function set_var($name, $value) {
+        // TODO: rename this to 'set_custom_config'. 'set_var' is too confusing.
         // Grabs the current raw config.
         $config = $this->get_config(false);
 
@@ -1034,70 +931,5 @@ class step extends persistent {
             helper::YAML_DUMP_INDENT_LEVEL,
             Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK
         );
-        $this->get_dataflow()->rebuild_variables();
-    }
-
-    /**
-     * Fills in output fields provided given an array of outputs
-     *
-     * @param  mixed $attributes array of output fields to set. This is merged with any existing values.
-     */
-    public function set_output($attributes) {
-        throw new \moodle_exception('set_output');
-        $this->outputs = $this->outputs ?? new \stdClass;
-        $this->outputs = (object) array_merge((array) $this->outputs, (array) $attributes);
-        $this->get_dataflow()->rebuild_variables();
-    }
-
-    /**
-     * Set variables to set under in the step root.
-     *
-     * @param mixed $variables
-     */
-    public function set_rootvariables($variables) {
-        $this->rootvariables = $this->rootvariables ?? new \stdClass;
-        $this->rootvariables = (object) array_merge((array) $this->rootvariables, (array) $variables);
-        $this->get_dataflow()->rebuild_variables();
-    }
-
-    /**
-     * Returns the step's variables for the root.
-     *
-     * @return  \stdClass
-     */
-    public function get_rootvariables(): \stdClass {
-        return $this->rootvariables ?? new \stdClass;
-    }
-
-    /**
-     * Set variables to set under the 'vars' subtree.
-     *
-     * @param mixed $variables
-     */
-    public function set_varsvariables($variables) {
-        $this->varsvariables = $this->varsvariables ?? new \stdClass;
-        $this->varsvariables = (object) array_merge((array) $this->varsvariables, (array) $variables);
-        $this->get_dataflow()->rebuild_variables();
-    }
-
-    /**
-     * Returns the step's variable for the 'vars' subtree.
-     *
-     * @return  \stdClass
-     */
-    public function get_varsvariables(): \stdClass {
-        return $this->varsvariables ?? new \stdClass;
-    }
-
-    /**
-     * Get the configuration and values but with secrets redacted
-     *
-     * @param   ?bool $expressions whether expressions are parsed or not
-     * @return  \stdClass $redactedconfig
-     */
-    public function get_redacted_config($expressions = true): \stdClass {
-        $redacted = true;
-        $redactedconfig = $this->get_config($expressions, $redacted);
-        return $redactedconfig;
     }
 }

--- a/classes/step.php
+++ b/classes/step.php
@@ -514,7 +514,7 @@ class step extends persistent {
             }
         }
 
-        $vars = $this->get_vars(false);
+        $vars = $this->get_vars();
         if (!helper::obj_empty($vars)) {
             $yaml['vars'] = $vars;
         }

--- a/classes/step.php
+++ b/classes/step.php
@@ -917,8 +917,7 @@ class step extends persistent {
      * @param  string $name or path to name of field e.g. 'some.nested.fieldname'
      * @param  mixed $value
      */
-    public function set_var($name, $value) {
-        // TODO: rename this to 'set_custom_config'. 'set_var' is too confusing.
+    public function set_config_by_name($name, $value) {
         // Grabs the current raw config.
         $config = $this->get_config(false);
 

--- a/classes/steps_table.php
+++ b/classes/steps_table.php
@@ -138,18 +138,19 @@ class steps_table extends sql_table {
         $redactedconfig = $step->get_redacted_config(false);
 
         // We want to display the vars definitions as well.
-        $vars = (array) $step->vars;
-        if (!empty($vars)) {
-            $redactedconfig->vars = $step->vars;
+        $vars = $step->get_raw_vars();
+        if (!helper::obj_empty($vars)) {
+            $redactedconfig->vars = $vars;
         }
-        $redactedconfig = (array) $redactedconfig;
-        $output = !empty($redactedconfig) ?
-                Yaml::dump(
-                    $redactedconfig,
-                    helper::YAML_DUMP_INLINE_LEVEL,
-                    helper::YAML_DUMP_INDENT_LEVEL,
-                    Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | YAML::DUMP_OBJECT_AS_MAP
-                ) : '';
+        if (helper::obj_empty($redactedconfig)) {
+            return '';
+        }
+        $output = Yaml::dump(
+            $redactedconfig,
+            helper::YAML_DUMP_INLINE_LEVEL,
+            helper::YAML_DUMP_INDENT_LEVEL,
+            Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | YAML::DUMP_OBJECT_AS_MAP
+        );
         return \html_writer::tag('pre', $output, ['style' => 'max-width: 30em;']);
     }
 

--- a/classes/task/process_dataflow_ad_hoc.php
+++ b/classes/task/process_dataflow_ad_hoc.php
@@ -36,7 +36,7 @@ class process_dataflow_ad_hoc extends \core\task\adhoc_task {
         $dataflowrecord = $this->get_custom_data();
 
         try {
-            $dataflow = new dataflow($dataflowrecord->dataflowid);
+            $dataflow = dataflow::get_dataflow($dataflowrecord->dataflowid);
             if ($dataflow->enabled) {
                 mtrace("Running dataflow $dataflow->name as ad-hoc task (ID: $dataflowrecord->dataflowid), time due: " .
                     userdate($dataflowrecord->nextruntime));

--- a/classes/task/process_dataflows.php
+++ b/classes/task/process_dataflows.php
@@ -51,7 +51,7 @@ class process_dataflows extends \core\task\scheduled_task {
         if (isset($firstdataflowrecord)) {
             // Create ad-hoc tasks for all but one dataflow.
             foreach ($dataflowrecords as $dataflowrecord) {
-                $dataflow = new dataflow($dataflowrecord->dataflowid);
+                $dataflow = dataflow::get_dataflow($dataflowrecord->dataflowid);
                 $task = new process_dataflow_ad_hoc();
                 $task->set_custom_data($dataflowrecord);
                 if ($dataflow->is_concurrency_enabled()) {

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -246,6 +246,7 @@ $string['here'] = 'here';
 $string['concurrency_disabled'] = 'Concurrency is not possible with this dataflow. Concurrent running flag has been set to false.';
 $string['concurrency_enabled_disabled_desc'] = '<i>Concurrent running is not possible because one or more steps are unable to support concurrency.
  While you can still edit this setting, it\'s value will be ignored. Reasons are:</i>';
+$string['no_variables'] = 'Cannot utilise variables without a meaningful context.';
 
 // JSON errors.
 $string['reader_json:failed_to_decode_json'] = 'Invalid JSON, failed to decode JSON file "{$a}".';

--- a/run.php
+++ b/run.php
@@ -67,7 +67,7 @@ require_capability('moodle/site:config', context_system::instance());
 $context = context_system::instance();
 
 // Find and set the dataflow, if not found, it will throw an exception.
-$dataflow = new dataflow($dataflowid);
+$dataflow = dataflow::get_dataflow($dataflowid);
 
 // Start output.
 $url = new moodle_url('/admin/tool/dataflows/run.php', ['dataflowid' => $dataflowid]);

--- a/tests/dataflows/test_dataflows.php
+++ b/tests/dataflows/test_dataflows.php
@@ -1,0 +1,98 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+use tool_dataflows\local\execution\flow_callback_step;
+use tool_dataflows\local\execution\test_step;
+
+defined('MOODLE_INTERNAL') || die();
+
+// These are needed. Files will not be automatically included.
+require_once(__DIR__ . '/../local/execution/array_in_type.php');
+require_once(__DIR__ . '/../local/execution/array_out_type.php');
+require_once(__DIR__ . '/../local/execution/flow_callback_step.php');
+
+/**
+ * Stock dataflows to be used in testing.
+ *
+ * @package   <insert>
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class test_dataflows {
+    /**
+     * Create a two step reader-writer using the static array in and array out test steps.
+     *
+     * @returns array [<dataflow>, <steps]
+     */
+    public static function array_in_array_out(): array {
+        $dataflow = new dataflow();
+        $dataflow->name = 'array-in-array-out';
+        $dataflow->enabled = true;
+        $dataflow->save();
+
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = 'tool_dataflows\local\execution\array_in_type';
+        $dataflow->add_step($reader);
+
+        $writer = new step();
+        $writer->name = 'writer';
+        $writer->type = 'tool_dataflows\local\execution\array_out_type';
+
+        $writer->depends_on([$reader]);
+        $dataflow->add_step($writer);
+        
+        return [$dataflow, ['reader' => $reader, 'writer' => $writer]];
+    }
+
+    /**
+     * Create a three step reader-callback-writer dataflow.
+     *
+     * @param string $readertype
+     * @param string $writertype
+     * @return array [<dataflow>, <steps]
+     */
+    public static function reader_callback_writer(string $readertype, string $writertype, callable $fn): array {
+        $dataflow = new dataflow();
+        $dataflow->name = 'reader-callback-writer';
+        $dataflow->enabled = true;
+        $dataflow->save();
+
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = $readertype;
+        $dataflow->add_step($reader);
+
+        $callback = new test_step();
+        $callback->name = 'callback';
+        $callback->type = flow_callback_step::class;
+        $callback->dodgyvars['callback'] = $fn;
+        $callback->depends_on([$reader]);
+        $dataflow->add_step($callback);
+
+        $writer = new step();
+        $writer->name = 'writer';
+        $writer->type = $writertype;
+        $writer->depends_on([$callback]);
+        $dataflow->add_step($writer);
+
+        return [$dataflow, ['reader' => $reader, 'callback' => $callback, 'writer' => $writer]];
+    }
+}
+

--- a/tests/local/execution/flow_callback_step.php
+++ b/tests/local/execution/flow_callback_step.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\execution;
+
+use tool_dataflows\local\execution\iterators\iterator;
+use tool_dataflows\local\execution\iterators\dataflow_iterator;
+use tool_dataflows\local\execution\flow_engine_step;
+use tool_dataflows\local\step\flow_step;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * A step that calls a callback for each execution.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class flow_callback_step extends flow_step {
+    public static $callback;
+
+    public function execute($inputs = null) {
+        $callback = $this->stepdef->dodgyvars['callback'];
+        call_user_func($callback, $inputs, $this);
+        return $inputs;
+    }
+}
+
+/**
+ * A special test step class that allows storing variables directly.
+ */
+class test_step extends \tool_dataflows\step {
+    /** @var mixed Some very dodgy variables used in testing. */
+    public $dodgyvars;
+}

--- a/tests/tool_dataflows_flow_hash_file_test.php
+++ b/tests/tool_dataflows_flow_hash_file_test.php
@@ -102,22 +102,21 @@ class tool_dataflows_flow_hash_file_test extends \advanced_testcase {
      */
     public function test_hashing_a_file_results_in_expected_hashes(string $filepath, string $expectedhash, string $algorithm) {
         [$dataflow, $steps] = $this->create_dataflow();
-        $hashfile = reset($steps);
+        $hashfilestep = reset($steps);
 
         // Needed here to ensure the path is 'allowed'.
         set_config('permitted_dirs', $filepath, 'tool_dataflows');
 
-        $hashfile->config = Yaml::dump(['path' => $filepath, 'algorithm' => $algorithm]);
+        $hashfilestep->config = Yaml::dump(['path' => $filepath, 'algorithm' => $algorithm]);
 
-        $isdryrun = false;
         $this->assertTrue($dataflow->validate_dataflow());
 
         ob_start();
-        $engine = new engine($dataflow, $isdryrun);
+        $engine = new engine($dataflow);
         $engine->execute();
         ob_get_clean();
 
         // Check and ensure hashes match.
-        $this->assertEquals($expectedhash, $dataflow->get_variables()['steps']->hashfile->hash);
+        $this->assertEquals($expectedhash, $hashfilestep->get_variables()->get_resolved('hash'));
     }
 }

--- a/tests/tool_dataflows_stream_writer_test.php
+++ b/tests/tool_dataflows_stream_writer_test.php
@@ -118,8 +118,11 @@ class tool_dataflows_stream_writer_test extends \advanced_testcase {
      * Tests the writer_stream reports side effects correctly.
      *
      * @covers \tool_dataflows\local\step\writer_stream::has_side_effect
+     * @dataProvider has_side_effect_provider
+     * @param string $streamname
+     * @param bool $expected
      */
-    public function test_has_side_effect() {
+    public function test_has_side_effect(string $streamname, bool $expected) {
         $steptype = new writer_stream();
         $this->assertTrue($steptype->has_side_effect());
 
@@ -132,12 +135,22 @@ class tool_dataflows_stream_writer_test extends \advanced_testcase {
         $step->name = 'somename';
         $step->type = 'tool_dataflows\local\step\writer_stream';
 
-        $step->config = Yaml::dump(['format' => 'json', 'streamname' => 'file:///home/out.txt', 'prettyprint' => true]);
+        $step->config = Yaml::dump(['format' => 'json', 'streamname' => $streamname, 'prettyprint' => true]);
         $dataflow->add_step($step);
         $steptype = $step->steptype;
-        $this->assertTrue($steptype->has_side_effect());
+        $this->assertEquals($expected, $steptype->has_side_effect());
+    }
 
-        $step->config = Yaml::dump(['format' => 'json', 'streamname' => 'rel/out.txt', 'prettyprint' => true]);
-        $this->assertFalse($steptype->has_side_effect());
+    /**
+     * Data provider for test_has_side_effect.
+     *
+     * @return array[]
+     */
+    public function has_side_effect_provider() {
+        return [
+            ['file:///home/out.txt', true],
+            ['rel/out.txt', false],
+            ['/rel/out.txt', true],
+        ];
     }
 }

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -312,15 +312,23 @@ class tool_dataflows_test extends \advanced_testcase {
         // evaluated until previous steps have run.
         $content = file_get_contents(dirname(__FILE__) . '/fixtures/sample-with-expressions.yml');
         $yaml = \Symfony\Component\Yaml\Yaml::parse($content);
+
         $dataflow = new dataflow();
         $dataflow->import($yaml);
-        $vars = $dataflow->vars;
-        $this->assertNotEquals($yaml['config']['expression'],  $vars->expression);
+        $expressionexpected = 'with steps notify and Read a value';
+
+        $variables = $dataflow->get_variables();
+        $vars = $variables->get_resolved('vars');
+
+        $this->assertEquals($yaml['vars']['expression'], $variables->get('vars.expression'));
+        $this->assertNotEquals($yaml['vars']['expression'],  $variables->get_resolved('vars.expression'));
+        $this->assertEquals($expressionexpected,  $variables->get_resolved('vars.expression'));
+        $this->assertEquals($expressionexpected,  $vars->expression);
+        $this->assertEquals($dataflow->id,  $variables->get_resolved('vars.expression_test_id'));
         $this->assertEquals($dataflow->id,  $vars->expression_test_id);
         $this->assertEquals($dataflow->name,  $vars->expression_dataflow_name);
         $this->assertEquals($dataflow->id + 777,  $vars->expression_math); // Adding an fixed number.
         $this->assertEquals('notifyread_value',  $vars->expression_concat); // Using the ~ operator.
-        $this->compatible_assertStringContainsString('steps notify and Read a value',  $vars->expression);
 
         // TODO: Add tests for parsing during a dataflow run (via the dataflow engine).
     }

--- a/tests/tool_dataflows_variables_execution_test.php
+++ b/tests/tool_dataflows_variables_execution_test.php
@@ -14,28 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-namespace tool_dataflows\local\execution;
+namespace tool_dataflows;
 
+use tool_dataflows\local\execution\array_in_type;
+use tool_dataflows\local\execution\array_out_type;
 use tool_dataflows\local\execution\engine;
-use tool_dataflows\dataflow;
-use tool_dataflows\step;
-use tool_dataflows\test_dataflows;
+use tool_dataflows\local\execution\flow_callback_step;
+use tool_dataflows\local\step\base_step;
 
 defined('MOODLE_INTERNAL') || die();
 
 // This is needed. File will not be automatically included.
-require_once(__DIR__ . '/../../dataflows/test_dataflows.php');
+require_once(__DIR__ . '/dataflows/test_dataflows.php');
 
 /**
- * Unit tests for the execution engine
+ * Tests the variables code within a dataflow execution.
  *
  * @package   tool_dataflows
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_dataflows_basic_execution_test extends \advanced_testcase {
-
+class tool_dataflows_variables_execution_test extends \advanced_testcase {
     /**
      * Set up before each test
      */
@@ -44,18 +44,18 @@ class tool_dataflows_basic_execution_test extends \advanced_testcase {
         $this->resetAfterTest();
     }
 
-    /**
-     * Tests the minimal ability for the execution engine. Reads in array data from a reader,
-     * and passes it on to a writer.
-     *
-     * @covers \tool_dataflows\local\execution\engine::execute
-     * @covers \tool_dataflows\local\execution\engine::execute_step
-     * @covers \tool_dataflows\local\execution\engine::finalise
-     * @covers \tool_dataflows\local\execution\engine::initialise
-     * @throws \moodle_exception
-     */
-    public function test_in_and_out() {
-        [$dataflow, $steps] = test_dataflows::array_in_array_out();
+    public function test_record() {
+        $tester = $this;
+        $callback = function ($inputs, base_step $step) use ($tester) {
+            $tester->assertTrue(true);
+            $tester->assertEquals($inputs, $step->get_engine_step()->get_variables()->get_resolved('record'));
+        };
+
+        [$dataflow, $steps] = test_dataflows::reader_callback_writer(
+            array_in_type::class,
+            array_out_type::class,
+            $callback
+        );
 
         // Define the input.
         $json = '[{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}]';
@@ -75,3 +75,4 @@ class tool_dataflows_basic_execution_test extends \advanced_testcase {
         $this->assertEquals(engine::STATUS_FINALISED, $engine->status);
     }
 }
+

--- a/tests/tool_dataflows_variables_root_test.php
+++ b/tests/tool_dataflows_variables_root_test.php
@@ -1,0 +1,126 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+use Symfony\Component\Yaml\Yaml;
+use tool_dataflows\local\execution;
+use tool_dataflows\local\execution\variables_root;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/local/execution/reader_sql_variable_setter.php');
+require_once(__DIR__ . '/application_trait.php');
+
+/**
+ * Tests the variabels functionality.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_variables_root_test extends \advanced_testcase {
+    use application_trait;
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Tests basic functionality of variables_root.
+     *
+     * @covers \tool_dataflows\local\execution\variables_root
+     * @covers \tool_dataflows\local\execution\variables_dataflow
+     * @covers \tool_dataflows\local\execution\variables_step
+     */
+    public function test_basic_functionality() {
+        $dataflow = new dataflow();
+        $dataflow->name = 'basic';
+        $dataflow->enabled = true;
+        $dataflow->save();
+
+        $reader = new step();
+        $reader->name = 'wait';
+        $reader->type = 'tool_dataflows\local\step\connector_wait';
+        $reader->set_var('timesec', 1);
+        $dataflow->add_step($reader);
+
+        $vars = new variables_root($dataflow);
+        $this->assertEquals(1, $vars->get('steps.wait.config.timesec'));
+        $this->assertEquals('wait', $vars->get('steps.wait.name'));
+
+        $dfvars = $vars->get('dataflow');
+        $this->assertEquals('basic', $dfvars->get('name'));
+
+        $stepvars = $vars->get_step_variables('wait');
+        $this->assertEquals(1, $stepvars->get('config.timesec'));
+        $stepvars->set('vars.dunno', '${{dataflow.name}}');
+
+        $this->assertEquals('basic', $vars->get_resolved('steps.wait.vars.dunno'));
+        $vars->set('dataflow.name', 'advanced');
+        $this->assertEquals('advanced', $vars->get_resolved('steps.wait.vars.dunno'));
+    }
+
+    /**
+     * Test self referencing variables, (but with valid and complete values)
+     *
+     * @covers \tool_dataflows\local\execution\variables_root::get_tree
+     */
+    public function test_variable_parsing_involving_self_recursion() {
+        // Create the dataflow.
+        $dataflow = new dataflow();
+        $dataflow->name = 'readwrite';
+        $dataflow->enabled = true;
+        $dataflow->save();
+
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = execution\reader_sql_variable_setter::class;
+
+        // Set the SQL query via a YAML config string.
+        $reader->config = Yaml::dump([
+            'sql' => 'select ${{ steps.reader.config.something + steps.reader.config.countervalue }}',
+            'countervalue' => '${{ steps.reader.config.counterfield + steps.reader.config.counterfield }}',
+            'counterfield' => '${{ steps.reader.config.something + 10 }}',
+            'something' => '1',
+        ]);
+        $dataflow->add_step($reader);
+
+        $writer = new step();
+        $writer->name = 'do-nothing-writer';
+        $writer->type = 'tool_dataflows\local\step\writer_debugging';
+        $writer->depends_on([$reader]);
+        $dataflow->add_step($writer);
+
+        $variables = new variables_root($dataflow);
+        $tree = $variables->get_tree();
+
+        $parser = new parser();
+        $expressedvalue = $parser->evaluate('${{steps.reader.config.sql}}', (array) $tree);
+        $this->assertEquals('select 23', $expressedvalue);
+        $expressedvalue = $parser->evaluate('${{steps.reader.config.something}}', (array) $tree);
+        $this->assertEquals(1, $expressedvalue);
+        $expressedvalue = $parser->evaluate('${{steps.reader.config.counterfield}}', (array) $tree);
+        $this->assertEquals(11, $expressedvalue);
+        $expressedvalue = $parser->evaluate('${{steps.reader.config.countervalue}}', (array) $tree);
+        $this->assertEquals(11 * 2, $expressedvalue);
+    }
+}

--- a/tests/tool_dataflows_variables_root_test.php
+++ b/tests/tool_dataflows_variables_root_test.php
@@ -60,7 +60,7 @@ class tool_dataflows_variables_root_test extends \advanced_testcase {
         $reader = new step();
         $reader->name = 'wait';
         $reader->type = 'tool_dataflows\local\step\connector_wait';
-        $reader->set_var('timesec', 1);
+        $reader->set_config_by_name('timesec', 1);
         $dataflow->add_step($reader);
 
         $vars = new variables_root($dataflow);


### PR DESCRIPTION
Resolves #614

This touches on a lot of areas. The main things to keep in mind.
- Variables are now done through the variables classes.
- You should write variables directly to the variables object.
- All expression parsing should, ideally, be done through variables.
- Always obtain resolved variables from the variables object via get_resolved().
- There has been some reshuffling of function names to improve consistency and intuitiveness.
- Ideally, dataflow and step classes should not have execution related code inside them.

Still to do (list is not complete).
- Get localisation to work.
- Fix up redaction.
