### PR TITLE
style: phpcs fixes

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -42,8 +42,9 @@ class dataflow extends persistent {
     /** @var bool Set to true when the dataflow is in the process of deleting. */
     private $isdeleting = false;
 
-    /** @var var_root The variables tree.  */
+    /** @var var_root The variables tree. */
     private $varroot = null;
+
     /**
      * Return the definition of the properties of this model.
      *
@@ -90,7 +91,6 @@ class dataflow extends persistent {
     public function __set($name, $value) {
         return $this->set($name, $value);
     }
-
 
     /**
      * Return the vars of the dataflow.

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -608,7 +608,7 @@ class engine {
     public function get_export_data(): array {
         $encoded = json_encode(
             $this->get_variables_root()->get(),
-            defined('JSON_INVALID_UTF8_SUBSTITUTE') ? JSON_INVALID_UTF8_SUBSTITUTE : 0
+            defined('JSON_INVALID_UTF8_SUBSTITUTE') ? JSON_INVALID_UTF8_SUBSTITUTE : 0 // phpcs:ignore
         );
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new \moodle_exception(json_last_error_msg());

--- a/classes/local/step/trigger_cron.php
+++ b/classes/local/step/trigger_cron.php
@@ -207,10 +207,10 @@ class trigger_cron extends trigger_step {
     /**
      * Get the next scheduled time
      *
-     * @param  object $config step config
+     * @param  \stdClass $config step config
      * @return int time for the next run
      */
-    public function get_next_scheduled_time(object $config) {
+    public function get_next_scheduled_time(\stdClass $config) {
         $config->classname = process_dataflows::class;
         $times = scheduler::get_scheduled_times($this->stepdef->id);
         if ($times === false) {

--- a/classes/local/variables/var_node.php
+++ b/classes/local/variables/var_node.php
@@ -27,7 +27,7 @@ namespace tool_dataflows\local\variables;
 abstract class var_node {
     /** @var string The local name of the node. */
     protected $name;
-    /** @var var_object|null  The parent node. */
+    /** @var var_object|null The parent node. */
     protected $parent;
 
     /** @var var_object The root of the variable tree. */
@@ -132,7 +132,6 @@ abstract class var_node {
      */
     public function __get(string $p) {
         switch ($p) {
-
             // Name fo this node.
             case 'name':
                 return $this->name;

--- a/classes/local/variables/var_object.php
+++ b/classes/local/variables/var_object.php
@@ -25,7 +25,7 @@ namespace tool_dataflows\local\variables;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class var_object extends var_node {
-    /** @var array[var_obj] The node's children.  */
+    /** @var array[var_obj] The node's children. */
     protected $children = [];
 
     /**

--- a/classes/local/variables/var_root.php
+++ b/classes/local/variables/var_root.php
@@ -30,6 +30,7 @@ use tool_dataflows\step;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class var_root extends var_object_visible {
+
     /**
      * Creates the variable tree.
      *

--- a/classes/local/variables/var_value.php
+++ b/classes/local/variables/var_value.php
@@ -37,7 +37,7 @@ class var_value extends var_node {
     /** @var array[var_value] All variables immediately dependent on this. */
     private $dependents = [];
 
-    /** @var mixed the original value with expressions unresolved. If null, then is 'unset'.  */
+    /** @var mixed the original value with expressions unresolved. If null, then is 'unset'. */
     private $raw = null;
     /** @var mixed The resolved value. */
     private $resolved;
@@ -167,7 +167,7 @@ class var_value extends var_node {
         $this->dependents = array_udiff(
             $this->dependents,
             [$var],
-            function($a, $b) {
+            function ($a, $b) {
                 return $a === $b;
             }
         );

--- a/tests/local/execution/var_object_for_testing.php
+++ b/tests/local/execution/var_object_for_testing.php
@@ -28,6 +28,7 @@ use tool_dataflows\local\variables\var_object_visible;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class var_object_for_testing extends var_object_visible {
+
     /**
      * Create it.
      *

--- a/tests/test_dataflows.php
+++ b/tests/test_dataflows.php
@@ -38,6 +38,7 @@ require_once(__DIR__ . '/local/execution/test_step.php');
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class test_dataflows {
+
     /**
      * Create a two step reader-writer using the static array in and array out test steps.
      *

--- a/tests/tool_dataflows_abort_test.php
+++ b/tests/tool_dataflows_abort_test.php
@@ -59,7 +59,7 @@ class tool_dataflows_abort_test extends \advanced_testcase {
             'source' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 4, 'b' => 5, 'c' => 6],
-            ]
+            ],
         ]);
 
         // Create the engine.

--- a/tests/tool_dataflows_variables_new_test.php
+++ b/tests/tool_dataflows_variables_new_test.php
@@ -16,7 +16,7 @@
 
 namespace tool_dataflows;
 
-use \tool_dataflows\local\variables\var_value;
+use tool_dataflows\local\variables\var_value;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -31,6 +31,7 @@ require_once(__DIR__ . '/local/execution/var_object_for_testing.php');
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_variables_new_test extends \advanced_testcase {
+
     /**
      * Test for empty (unset) values.
      *
@@ -82,13 +83,14 @@ class tool_dataflows_variables_new_test extends \advanced_testcase {
             'a' => [
                 'b' => ['c' => 'two', 'a' => 3],
                 'a' => 1,
-                'c' => ['a' => 8, 'b' => 9, 'c' => 10]
-            ]
+                'c' => ['a' => 8, 'b' => 9, 'c' => 10],
+            ],
         ]);
 
         $vars->set('a', $obj);
         $this->assertEquals($expected, json_encode($vars->get()));
     }
+
     /**
      * Test use of expressions.
      *


### PR DESCRIPTION
Issues fixed:
      1 - An import use statement should never start with a leading backslash
      1 - Blank line found at start of control structure
      3 - Each line in an array declaration must end in a comma
      2 - Expected a blank line after function
      5 - Expected a blank line before function
      1 - Expected a space after FUNCTION keyword
      1 - Multi-line array contains a single value
