### PR TITLE
Moodle 35 stable cronandcurl

### DIFF
--- a/classes/local/step/connector_curl.php
+++ b/classes/local/step/connector_curl.php
@@ -19,6 +19,10 @@ namespace tool_dataflows\local\step;
 use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\helper;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/filelib.php');
+
 /**
  * CURL connector step type
  *

--- a/classes/local/step/trigger_cron.php
+++ b/classes/local/step/trigger_cron.php
@@ -293,7 +293,7 @@ class trigger_cron extends trigger_step {
                 $this->stepdef->dataflowid,
                 $this->stepdef->id,
                 $newtime,
-                $config->nextruntime
+                $config->nextruntime ?? null
             );
         }
     }


### PR DESCRIPTION
This PR solves an undefined error aborting cron run and an unfound curl class.

Regards,

Marc