### PR TITLE
Add sql flow step

### DIFF
--- a/classes/local/step/flow_sql.php
+++ b/classes/local/step/flow_sql.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\step;
+
+/**
+ * SQL flow step
+ *
+ * @package   tool_dataflows
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class flow_sql extends flow_step {
+    use sql_trait;
+
+    /**
+     * Return the definition of the fields available in this form.
+     *
+     * @return array
+     */
+    public static function form_define_fields(): array {
+        return [
+            'sql' => ['type' => PARAM_TEXT, 'required' => true]
+        ];
+    }
+
+    /**
+     * Allows each step type to determine a list of optional/required form
+     * inputs for their configuration
+     *
+     * It's recommended you prefix the additional config related fields to avoid
+     * conflicts with any existing fields.
+     *
+     * @param \MoodleQuickForm $mform
+     */
+    public function form_add_custom_inputs(\MoodleQuickForm &$mform) {
+        // SQL example and inputs.
+        $sqlexample = "
+        SELECT id, username
+          FROM {user}
+      WHERE id > \${{steps.xyz.var.number}}
+      ORDER BY id ASC
+         LIMIT 10";
+        $sqlexamples = \html_writer::tag('pre', trim($sqlexample, " \t\r\0\x0B"));
+        $mform->addElement('textarea', 'config_sql', get_string('flow_sql:sql', 'tool_dataflows'),
+            ['cols' => 50, 'rows' => 7, 'style' => 'font: 87.5% monospace;']);
+        $mform->addElement('static', 'config_sql_help', '', get_string('flow_sql:sql_help', 'tool_dataflows', $sqlexamples));
+    }
+
+    /**
+     * Execute configured query
+     *
+     * @param   mixed $input
+     * @return  mixed
+     * @throws \dml_read_exception when the SQL is not valid.
+     */
+    public function execute($input = null) {
+        global $DB;
+
+        // Construct the query.
+        $variables = $this->get_variables();
+        $config = $variables->get('config');
+        $sql = $this->evaluate_expressions($config->sql);
+
+        // Execute the query using get_records instead of get_record.
+        // This is so we can expose the number of records returned which
+        // can then be used by the dataflow in for e.g. a switch statement.
+        $records = $DB->get_records_sql($sql);
+
+        $variables->set('count', count($records));
+
+        // Only return the query data if there is exactly 1 record.
+        // If multiple records are returned, it is undefined what should happen.
+        $invalidnum = ($records === false || count($records) !== 1);
+        $data = $invalidnum ? null : array_pop($records);
+        $variables->set('data', $data);
+    }
+
+    /**
+     * Validate the configuration settings.
+     *
+     * @param   object $config
+     * @return  true|\lang_string[] true if valid, an array of errors otherwise
+     */
+    public function validate_config($config) {
+        $errors = [];
+        if (empty($config->sql)) {
+            $errors['config_sql'] = get_string('config_field_missing', 'tool_dataflows', 'sql', true);
+        }
+
+        return empty($errors) ? true : $errors;
+    }
+}

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -39,6 +39,7 @@ use tool_dataflows\parser;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class reader_sql extends reader_step {
+    use sql_trait;
 
     /**
      * Return the definition of the fields available in this form.
@@ -182,112 +183,9 @@ class reader_sql extends reader_step {
         }
 
         // Evalulate any remaining expressions as per normal.
-        // NOTE: The expression statement itself MUST be on a single line (currently).
-        $hasexpression = true;
-        $max = 5;
-        while ($hasexpression && $max) {
-            $finalsql = $variables->evaluate($finalsql, function ($message, $e) {
-                // Process the message and clarify it if required.
-                $message = $this->clarify_parser_error($message);
-
-                // Log the message.
-                $this->enginestep->log($message);
-
-                // Throw the original exception (i.e. for the real stack trace).
-                throw $e;
-            });
-            if (!is_string($finalsql)) {
-                throw new \moodle_exception('reader_sql:finalsql_not_string', 'tool_dataflows');
-            }
-            [$hasexpression] = $parser->has_expression($finalsql);
-            $max--;
-        }
+        $finalsql = $this->evaluate_expressions($finalsql);
 
         return $finalsql;
-    }
-
-    /**
-     * Returns a clarified error message if applicable.
-     *
-     * @param   string $message
-     * @param   string $sql replacement for the expression held by default.
-     * @return  string clarified message if applicable
-     */
-    private function clarify_parser_error(string $message, ?string $sql = null): string {
-        // Check and massage the message if required.
-        $matches = null;
-        preg_match_all(
-            // phpcs:disable moodle.Strings.ForbiddenStrings.Found
-            '/Variable "(?<expressionpath>.*)" is not valid.*`(?<expression>.*)`.*for expression (?<sql>.*)/ms',
-            $message,
-            $matches,
-            PREG_SET_ORDER);
-
-        if (!empty($matches)) {
-            // Modify the SQL, adding a pointer to the first instance of the usage which resulted in the error.
-            $match = (object) reset($matches);
-
-            // Replace the field (using the sql key) in the matching expression with the one provided.
-            if (isset($sql)) {
-                $match->sql = $sql;
-            }
-
-            // Pinpoint the line and column of the expression in the SQL.
-            $line = 0;
-            $column = 0;
-            $sqlbylines = explode("\n", $match->sql);
-            foreach ($sqlbylines as $lineindex => $linecontents) {
-                $position = strpos($linecontents, $match->expression);
-                if ($position !== false) {
-                    $column = $position + 1;
-                    $line = $lineindex + 1;
-                    break;
-                }
-            }
-            // Insert the characters in the following line.
-            $sqlwithannotations = $this->draw_arrow_to_string_position($match->sql, $column, $line);
-            $a = (object) array_merge((array) $match, [
-                'sql' => $sqlwithannotations,
-                'column' => $column,
-                'line' => $line,
-            ]);
-            $message = get_string('reader_sql:variable_not_valid_in_position_replacement_text', 'tool_dataflows', $a);
-        }
-
-        return $message;
-    }
-
-    /**
-     * Draws an arrow pointing at the focused position in a string
-     *                                ^
-     * @param   string $string of the original contents
-     * @param   int $column column position to focus on
-     * @param   int $line line position to focus on
-     * @return  string with arrow annotation
-     */
-    private function draw_arrow_to_string_position(string $string, int $column, int $line) {
-        // Split by lines to ensure we insert it at the appropriate line.
-        $sqlbylines = explode("\n", $string);
-
-        // Insert the characters in the following line.
-        $arrow = str_pad('', $column - 1, ' ') . '^';
-        array_splice($sqlbylines, $line, 0, $arrow);
-
-        return implode("\n", $sqlbylines);
-    }
-
-    /**
-     * Validate the configuration settings.
-     *
-     * @param   object $config
-     * @return  true|\lang_string[] true if valid, an array of errors otherwise
-     */
-    public function validate_config($config) {
-        $errors = [];
-        if (empty($config->sql)) {
-            $errors['config_sql'] = get_string('config_field_missing', 'tool_dataflows', 'sql', true);
-        }
-        return empty($errors) ? true : $errors;
     }
 
     /**

--- a/classes/local/step/sql_trait.php
+++ b/classes/local/step/sql_trait.php
@@ -1,0 +1,152 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\local\step;
+
+use tool_dataflows\parser;
+
+/**
+ * SQL Trait
+ *
+ * @package    tool_dataflows
+ * @author     Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @author     Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright  Catalyst IT, 2022
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+trait sql_trait {
+
+    /**
+     * Evaluates exressions inside the given SQL query.
+     * E.g. replaces variables inside the query.
+     *
+     * NOTE: The expression statement itself MUST be on a single line (currently).
+     *
+     * @param string $sql input sql query string
+     * @return string sql string with expressions evaluated.
+     * @throws \moodle_exception when the SQL does not get evaluated correctly.
+     */
+    private function evaluate_expressions(string $sql) {
+        $variables = $this->get_variables();
+        $parser = parser::get_parser();
+
+        $hasexpression = true;
+        $max = 5;
+        while ($hasexpression && $max) {
+            $sql = $variables->evaluate($sql, function ($message, $e) {
+                // Process the message and clarify it if required.
+                $message = $this->clarify_parser_error($message);
+
+                // Log the message.
+                $this->enginestep->log($message);
+
+                // Throw the original exception (i.e. for the real stack trace).
+                throw $e;
+            });
+            if (!is_string($sql)) {
+                throw new \moodle_exception('reader_sql:finalsql_not_string', 'tool_dataflows');
+            }
+            [$hasexpression] = $parser->has_expression($sql);
+            $max--;
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Returns a clarified error message if applicable.
+     *
+     * @param   string $message
+     * @param   string $sql replacement for the expression held by default.
+     * @return  string clarified message if applicable
+     */
+    private function clarify_parser_error(string $message, ?string $sql = null): string {
+        // Check and massage the message if required.
+        $matches = null;
+        preg_match_all(
+            // phpcs:disable moodle.Strings.ForbiddenStrings.Found
+            '/Variable "(?<expressionpath>.*)" is not valid.*`(?<expression>.*)`.*for expression (?<sql>.*)/ms',
+            $message,
+            $matches,
+            PREG_SET_ORDER);
+
+        if (!empty($matches)) {
+            // Modify the SQL, adding a pointer to the first instance of the usage which resulted in the error.
+            $match = (object) reset($matches);
+
+            // Replace the field (using the sql key) in the matching expression with the one provided.
+            if (isset($sql)) {
+                $match->sql = $sql;
+            }
+
+            // Pinpoint the line and column of the expression in the SQL.
+            $line = 0;
+            $column = 0;
+            $sqlbylines = explode("\n", $match->sql);
+            foreach ($sqlbylines as $lineindex => $linecontents) {
+                $position = strpos($linecontents, $match->expression);
+                if ($position !== false) {
+                    $column = $position + 1;
+                    $line = $lineindex + 1;
+                    break;
+                }
+            }
+            // Insert the characters in the following line.
+            $sqlwithannotations = $this->draw_arrow_to_string_position($match->sql, $column, $line);
+            $a = (object) array_merge((array) $match, [
+                'sql' => $sqlwithannotations,
+                'column' => $column,
+                'line' => $line,
+            ]);
+            $message = get_string('reader_sql:variable_not_valid_in_position_replacement_text', 'tool_dataflows', $a);
+        }
+
+        return $message;
+    }
+
+    /**
+     * Draws an arrow pointing at the focused position in a string
+     *                                ^
+     * @param   string $string of the original contents
+     * @param   int $column column position to focus on
+     * @param   int $line line position to focus on
+     * @return  string with arrow annotation
+     */
+    private function draw_arrow_to_string_position(string $string, int $column, int $line) {
+        // Split by lines to ensure we insert it at the appropriate line.
+        $sqlbylines = explode("\n", $string);
+
+        // Insert the characters in the following line.
+        $arrow = str_pad('', $column - 1, ' ') . '^';
+        array_splice($sqlbylines, $line, 0, $arrow);
+
+        return implode("\n", $sqlbylines);
+    }
+
+    /**
+     * Validate the configuration settings.
+     *
+     * @param   object $config
+     * @return  true|\lang_string[] true if valid, an array of errors otherwise
+     */
+    public function validate_config($config) {
+        $errors = [];
+        if (empty($config->sql)) {
+            $errors['config_sql'] = get_string('config_field_missing', 'tool_dataflows', 'sql', true);
+        }
+        return empty($errors) ? true : $errors;
+    }
+}

--- a/classes/local/step/writer_stream.php
+++ b/classes/local/step/writer_stream.php
@@ -180,6 +180,11 @@ class writer_stream extends writer_step {
              * Called when the iterator is stopped, either because of finishing ar due to an abort.
              */
             public function on_stop() {
+                // If the stream is already closed, ignore.
+                if (!is_resource($this->handle)) {
+                    return;
+                }
+
                 if (fwrite($this->handle, $this->writer->close_output()) === false) {
                     $this->step->log(error_get_last()['message']);
                     throw new \moodle_exception(

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -138,6 +138,7 @@ $string['step_name_trigger_cron'] = 'Cron';
 $string['step_name_writer_debugging'] = 'Debugging writer';
 $string['step_name_writer_stream'] = 'Stream writer';
 $string['step_name_trigger_event'] = 'Moodle event';
+$string['step_name_flow_sql'] = 'SQL';
 
 // Step (type) groups.
 $string['stepgrouptriggers'] = 'Triggers';
@@ -496,3 +497,7 @@ $string['trigger_event:form:executionpolicy'] = 'Execution policy';
 $string['trigger_event:variable:event'] = 'Data included in the Moodle event';
 $string['trigger_event:form:eventname_help'] = 'Select the event to listen to. Note if the event is changed after a step is created, previously captured events queued for processing will be purged.';
 $string['trigger_event:form:executionpolicy_help'] = 'If the dataflow does not support concurrent running, serial processing will be used instead of parallel processing';
+
+// SQL flow step.
+$string['flow_sql:sql'] = 'SQL';
+$string['flow_sql:sql_help'] = 'You may use expressions with the SQL such as variables from other steps.';

--- a/lib.php
+++ b/lib.php
@@ -77,6 +77,7 @@ function tool_dataflows_step_types() {
         new step\writer_debugging,
         new step\writer_stream,
         new step\trigger_event,
+        new step\flow_sql,
     ];
 }
 

--- a/tests/tool_dataflows_flow_sql_test.php
+++ b/tests/tool_dataflows_flow_sql_test.php
@@ -1,0 +1,277 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+use Symfony\Component\Yaml\Yaml;
+use tool_dataflows\dataflow;
+use tool_dataflows\local\execution\engine;
+use tool_dataflows\step;
+use tool_dataflows\local\step\flow_sql;
+
+defined('MOODLE_INTERNAL') || die();
+
+// Include lib.php functions that aren't included automatically for Moodle 37- and below.
+require_once(dirname(__FILE__) . '/../lib.php');
+
+/**
+ * Unit test for the SQL flow step.
+ *
+ * @package   tool_dataflows
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright 2022, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_flow_sql_test extends \advanced_testcase {
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        set_config('permitted_dirs', '/tmp', 'tool_dataflows');
+
+        // Create a test dataflow.
+        $dataflow = new dataflow();
+        $dataflow->name = 'sql-flow';
+        $dataflow->enabled = true;
+        $dataflow->save();
+
+        $this->inputpath = tempnam('', 'tool_dataflows/input');
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = 'tool_dataflows\local\step\reader_json';
+        $reader->config = Yaml::dump([
+            'pathtojson' => $this->inputpath,
+            'arrayexpression' => 'data',
+            'arraysortexpression' => '',
+        ]);
+        $dataflow->add_step($reader);
+
+        $flow = new step();
+        $flow->name = 'flow';
+        $flow->type = 'tool_dataflows\local\step\flow_sql';
+
+        $flow->config = Yaml::dump(['sql' => 'SELECT * FROM {course}']);
+        $flow->depends_on([$reader]);
+        $dataflow->add_step($flow);
+
+        $this->outputpath = tempnam('', 'tool_dataflows/output');
+        $writer = new step();
+        $writer->name = 'stream-writer';
+        $writer->type = 'tool_dataflows\local\step\writer_stream';
+        $writer->config = Yaml::dump([
+            'format' => 'json',
+            'streamname' => $this->outputpath,
+        ]);
+        $writer->depends_on([$flow]);
+        $dataflow->add_step($writer);
+
+        $this->flow = $flow;
+        $this->writer = $writer;
+        $this->dataflow = $dataflow;
+    }
+
+    /**
+     * Creates a desired number of iterations in the test flow's json_reader step.
+     *
+     * @param int $rows number of rows to generate.
+     */
+    private function create_iterator_data(int $rows) {
+        $data = array_map(function($rownum) {
+            return (object) ['id' => $rownum];
+        }, range(1, $rows));
+
+        $json = json_encode((object) [
+            'data' => $data,
+            'modified' => [1654058940],
+            'errors' => [],
+        ]);
+
+        // Write initial contents to file for reader to pick up.
+        $stream = fopen($this->inputpath, 'w');
+        fwrite($stream, $json);
+        fclose($stream);
+    }
+
+    /**
+     * Tests normal execution of the step.
+     *
+     * @covers \tool_dataflows\local\step\flow_sql::execute
+     */
+    public function test_execute() {
+        global $DB;
+
+        // By default 1 course always exists.
+        $numcourses = $DB->count_records('course');
+        $this->assertEquals(1, $numcourses);
+
+        $iteratorcount = 5;
+        $this->create_iterator_data($iteratorcount);
+
+        // Run the dataflow unmodified from setUp().
+        ob_start();
+        $engine = new engine($this->dataflow);
+        $engine->execute();
+        ob_get_clean();
+
+        // Check they were queried back successfully.
+        $stepoutput = json_decode(file_get_contents($this->outputpath));
+        $this->assertCount($iteratorcount, $stepoutput);
+
+        // Check the variables of the engine on the last iteration, all iterations will have the same data anyway.
+        $variables = $engine->get_variables_root()->get();
+        $lastiterationrowcount = $variables->steps->flow->count;
+        $this->assertEquals($numcourses, $lastiterationrowcount);
+    }
+
+    /**
+     * Tests execution with expressions within the SQL.
+     *
+     * @covers \tool_dataflows\local\step\flow_sql::execute
+     */
+    public function test_execute_with_expressions() {
+        // Create a course and set its ID as a config variable to use in a query.
+        $course = $this->getDataGenerator()->create_course();
+        $iteratorcount = 5;
+        $this->create_iterator_data($iteratorcount);
+
+        $this->dataflow->vars = Yaml::dump([
+            'courseid' => $course->id
+        ]);
+        $this->dataflow->save();
+
+        $this->flow->config = Yaml::dump([
+            'sql' => 'SELECT * FROM {course} WHERE id = ${{dataflow.vars.courseid}}'
+        ]);
+        $this->flow->save();
+
+        ob_start();
+        $engine = new engine($this->dataflow);
+        $engine->execute();
+        ob_get_clean();
+
+        // Check they were queried back successfully.
+        $stepoutput = json_decode(file_get_contents($this->outputpath));
+        $this->assertCount($iteratorcount, $stepoutput);
+
+        // Check the variables of the engine on the last iteration, all iterations will have the same data anyway.
+        $variables = $engine->get_variables_root()->get();
+        $lastiterationflow = $variables->steps->flow;
+        $this->assertEquals($course->id, $lastiterationflow->data->id);
+        $this->assertEquals(1, $lastiterationflow->count);
+    }
+
+    /**
+     * Tests execution when the sql is not well formed.
+     *
+     * @covers \tool_dataflows\local\step\flow_sql::execute
+     */
+    public function test_execute_bad_sql() {
+        $this->create_iterator_data(1);
+
+        // Execute a query where the sql is not well formed.
+        // This should return null and a count of 0.
+        $this->flow->config = Yaml::dump([
+            'sql' => 'SELECT *'
+        ]);
+        $this->flow->save();
+
+        ob_start();
+        try {
+            $engine = new engine($this->dataflow);
+            $engine->execute();
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('dml_read_exception', $e);
+        }
+
+        ob_get_clean();
+    }
+
+    /**
+     * Tests execution when there are no records found.
+     * Should return null data and 0 count.
+     *
+     * @covers \tool_dataflows\local\step\flow_sql::execute
+     */
+    public function test_execute_no_records() {
+        $this->create_iterator_data(1);
+
+        // Execute a query where no records are returned.
+        // This should return null and a count of 0.
+        $this->flow->config = Yaml::dump([
+            'sql' => 'SELECT * FROM {course} WHERE id = -1'
+        ]);
+        $this->flow->save();
+
+        ob_start();
+        $engine = new engine($this->dataflow);
+        $engine->execute();
+        ob_get_clean();
+
+        $variables = $engine->get_variables_root()->get();
+        $lastiterationflow = $variables->steps->flow;
+        $this->assertNull($lastiterationflow->data);
+        $this->assertEquals(0, $lastiterationflow->count);
+    }
+
+    /**
+     * Tests executing when there are multiple records found.
+     * Should return null data and the correct count.
+     *
+     * @covers \tool_dataflows\local\step\flow_sql::execute
+     */
+    public function test_execute_multiple_records() {
+        global $DB;
+        $this->create_iterator_data(1);
+
+        // Create multiple courses, and trigger the dataflow.
+        // This should return a correct count but a record of null.
+        $this->getDataGenerator()->create_course();
+        $this->getDataGenerator()->create_course();
+        $numcourses = $DB->count_records('course');
+
+        ob_start();
+        $engine = new engine($this->dataflow);
+        $engine->execute();
+        ob_get_clean();
+
+        $variables = $engine->get_variables_root()->get();
+        $lastiterationflow = $variables->steps->flow;
+        $this->assertNull($lastiterationflow->data);
+        $this->assertEquals($numcourses, $lastiterationflow->count);
+    }
+
+    /**
+     * Tests config validation.
+     *
+     * @covers \tool_dataflows\local\step\flow_sql::validate_config
+     */
+    public function test_validate_config() {
+        // Test valid configuration.
+        $config = (object) ['sql' => 'SELECT * FROM {course}'];
+        $flow = new flow_sql();
+        $this->assertTrue($flow->validate_config($config));
+
+        // Test missing sql value.
+        $config = (object) ['notsql' => 'SELECT * FROM {course}'];
+        $result = $flow->validate_config($config);
+        $this->assertTrue(is_array($result));
+        $this->assertArrayHasKey('config_sql', $result);
+        $this->assertEquals(get_string('config_field_missing', 'tool_dataflows', 'sql'), $result['config_sql']);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022111800;
+$plugin->version = 2022112100;
 $plugin->release = 2022102600;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
## Summary:

1. New `flow_sql` step - this is for reading a single row using for e.g. variables. 
3. Refactored `reader_sql` with a new `sql_trait` - this is shared by the new `flow_sql` step. Note not all of the functions have been moved into the trait, for e.g. the row counting variable logic is redundant in the flow_sql step, so it only exists within the reader_sql step.
4. Fixed a tiny bug with the `stream_writer` that was causing the flow_sql unit tests to fail #673

## Functional testing
Create a small test course to generate users, then import the test dataflow  (rename to yml github doesn't allow straight yaml)
[Test_20221121_0211.txt](https://github.com/catalyst/moodle-tool_dataflows/files/10052034/Test_20221121_0211.txt)

This dataflow does the following:
1. Uses the sql reader to read enrolments and gets the $userid
2. Uses the new Flow SQL step to lookup a username from the $userid
3. Sends an email to test@test.com with the username gathered from the flow_sql call.
4. Check your Mailhog to confirm you get emails for each tool_generator user that was generated 

## Closes issues 

Closes #671 
Closes #673 