### PR TITLE
Nested Loop fix : strict value comparison add_dependent method

### DIFF
--- a/classes/local/variables/var_value.php
+++ b/classes/local/variables/var_value.php
@@ -179,7 +179,7 @@ class var_value extends var_node {
      * @param var_value $var
      */
     protected function add_dependent(var_value $var) {
-        if (!in_array($var, $this->dependents)) {
+        if (!in_array($var, $this->dependents, true)) {
             $this->dependents[] = $var;
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/76186988/204335801-0a233224-b80b-4061-a89d-9ec0edbd471c.png)

This issue happens with latest flow provided in ticket 384019, adding a variable in web service flow ${{ steps.get_course_details.vars.<var> }}