### PR TITLE
Moodle 35 stable langfix

### DIFF
--- a/classes/local/provider/expression_provider.php
+++ b/classes/local/provider/expression_provider.php
@@ -65,6 +65,7 @@ class expression_provider implements ExpressionFunctionProviderInterface {
             ExpressionFunction::fromPhp('userdate', 'userdate'),
             ExpressionFunction::fromPhp('date', 'date'),
             ExpressionFunction::fromPhp('get_object_vars', 'get_object_vars'),
+            ExpressionFunction::fromPhp('strtotime', 'strtotime'),
         ];
     }
 }

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -484,7 +484,7 @@ $string['variables:no_step_definition'] = 'Cannot get variables without a step d
 
 // Set variable step.
 $string['set_variable:field'] = 'Field';
-$string['set_variable:field_help'] = 'Defines the path to the field you would like to set the value. For example: <code>dataflows.vars.counter</code>.';
+$string['set_variable:field_help'] = 'Defines the path to the field you would like to set the value. For example: <code>dataflow.vars.counter</code>.';
 $string['set_variable:value'] = 'Value';
 $string['set_variable:value_help'] = 'The value could be a number, text, or an expression. For example: <code>${{ record.id }}</code>.';
 


### PR DESCRIPTION
Hi this PR includes 2 commits, one for the dataflow description in `set_variable` and another one adding `strtotime` function to expression provider, which is necessary to convert ISO 8601 date format to unix timestamp.

Regards,

Marc