### PR TITLE
Issue #716: Fix so that values can be passed through.

### DIFF
--- a/NEW_STEP.md
+++ b/NEW_STEP.md
@@ -23,6 +23,7 @@ Several convenience methods have been added to make this process a bit easier. Y
 - `$this->get_config()` which returns the configuration of the step, as an **object**, with all the expressions already evaluated.
 - `$this->is_dry_run()` which returns whether the dataflow was executed under dry run mode.
 - `$this->log()` which allows you to log a message during execution which if run directly would print the message to the user.
+-  $this->get_variables() which accesses the variables associated with this step.
 - Variables can be exposed when your step gets some new data which you want to make available in other steps. - See [variables](./VARIABLES.md) 
 
 For the general gist of how things are structured, please look at the existing examples:
@@ -31,3 +32,5 @@ For the general gist of how things are structured, please look at the existing e
 
 There are some differences between flow, reader and connector steps that may need to be taken into account.
 
+Execute() for flow steps takes in the current value for the iteration (which is also available as the variable 'record').
+Your step can modify the value to be passed on to later steps by returning the new value from the execute method.

--- a/classes/local/execution/iterators/iterator.php
+++ b/classes/local/execution/iterators/iterator.php
@@ -50,10 +50,23 @@ interface iterator {
     public function is_ready(): bool;
 
     /**
+     * Return the current element
+     *
+     * @return mixed can return any type
+     */
+    public function current();
+
+    /**
+     * Checks if current position is valid
+     *
+     * @return bool
+     */
+    public function valid(): bool;
+
+    /**
      * Next item in the stream.
      *
      * @param   \stdClass $caller The engine step that called this method, internally used to connect outputs.
-     * @return  \stdClass|bool A JSON compatible \stdClass, or false if nothing returned.
      */
     public function next($caller);
 }

--- a/classes/local/step/file_put_content_trait.php
+++ b/classes/local/step/file_put_content_trait.php
@@ -117,5 +117,7 @@ trait file_put_content_trait {
 
         $this->log("Saving to $path");
         file_put_contents($path, $config->content);
+
+        return $input;
     }
 }

--- a/classes/local/step/flow_sql.php
+++ b/classes/local/step/flow_sql.php
@@ -88,6 +88,8 @@ class flow_sql extends flow_step {
         $invalidnum = ($records === false || count($records) !== 1);
         $data = $invalidnum ? null : array_pop($records);
         $variables->set('data', $data);
+
+        return $input;
     }
 
     /**

--- a/classes/local/step/flow_step.php
+++ b/classes/local/step/flow_step.php
@@ -53,7 +53,7 @@ abstract class flow_step extends base_step {
      * something else.
      *
      * @param mixed|null $input
-     * @return mixed
+     * @return mixed The altered value to be passed to the next step(s) in the flow, or false to skip the rest of this iteration.
      */
     public function execute($input = null) {
         // Default is to do nothing.

--- a/classes/local/step/flow_transformer_filter.php
+++ b/classes/local/step/flow_transformer_filter.php
@@ -71,104 +71,19 @@ class flow_transformer_filter extends flow_transformer_step {
     }
 
     /**
-     * Get the iterator for the step, based on configurations.
+     * Execute the step.
      *
-     * @return  iterator
+     * Tests an expression. If the expression evaluates to 'true', the input will be returned. Otherwise 'false' will be returned.
+     *
+     * @param mixed|null $input
+     * @return mixed
      */
-    public function get_iterator(): iterator {
-        $upstream = current($this->enginestep->upstreams);
-        if ($upstream === false || !$upstream->is_flow()) {
-            throw new \moodle_exception(get_string('non_reader_steps_must_have_flow_upstreams', 'tool_dataflows'));
-        }
-
-        /*
-         * Iterator class to handle when to pull from upstream based on the condition of the current value.
-         */
-        return new class($this->enginestep, $upstream->iterator) extends dataflow_iterator {
-
-            protected $expr = true;
-
-            /**
-             * Create an instance of this class.
-             *
-             * @param  flow_engine_step $step
-             * @param  iterator $input
-             */
-            public function __construct(flow_engine_step $step, iterator $input) {
-                $this->expr = $step->stepdef->config->filter;
-                parent::__construct($step, $input);
-            }
-
-            /**
-             * Next item in the stream.
-             *
-             * @param   \stdClass $caller The engine step that called this method, internally used to connect outputs.
-             * @return  \stdClass|bool A JSON compatible \stdClass, or false if nothing returned.
-             */
-            public function next($caller) {
-                $now = microtime(true);
-                $stepvars = $this->steptype->get_variables();
-                $stepvars->set('timeentered', $now);
-
-                if ($this->finished) {
-                    return false;
-                }
-
-                // Do not call this for the initial pull (of data) for a step that has a producing iterator (e.g. readers).
-                if ($this->should_pull_next()) {
-                    if ($this->input instanceof dataflow_iterator) {
-                        $this->input->next($this);
-                    } else {
-                        $this->input->next();
-                    }
-                }
-                if ($this->step->engine->is_aborted()) {
-                    return false;
-                }
-                $this->pulled = true;
-
-                // Validate if input is valid before grabbing it.
-                if (!$this->input->valid()) {
-                    $this->finish();
-                    return false;
-                }
-
-                // Grabs the current value if valid.
-                $this->value = $this->input->current();
-
-                // If the current value is false, it should just fall right through and do nothing.
-                if ($this->value === false) {
-                    return false;
-                }
-
-                $stepvars->set('record', $this->value);
-
-                try {
-                    // Evaluate the expression.
-                    // If true then it will pass the input on. Otherwise it will pass on false.
-                    $result = (bool) $stepvars->evaluate('${{ ' . $this->expr . ' }}');
-
-                    if (!$result) {
-                        $this->value = false;
-                    }
-
-                    // Log vars for this iteration.
-                    $this->steptype->log_vars();
-
-                    ++$this->iterationcount;
-
-                    // Expose the number of times this step has been iterated over.
-                    $stepvars->set('iterations', $this->iterationcount);
-
-                    $this->step->log('Iteration ' . $this->iterationcount);
-                } catch (\Throwable $e) {
-                    $this->step->log($e->getMessage());
-                    $this->step->engine->abort();
-                    throw $e;
-                }
-
-                return $this->value;
-            }
+    public function execute($input = null) {
+        $expr = $this->stepdef->config->filter;
+        $result = (bool) $this->get_variables()->evaluate('${{ ' . $expr . ' }}');
+        if (!$result) {
+            return false;
         };
+        return $input;
     }
 }

--- a/classes/local/step/trigger_event.php
+++ b/classes/local/step/trigger_event.php
@@ -41,7 +41,7 @@ class trigger_event extends trigger_step {
     public function execute($input = null) {
         $variables = $this->get_variables();
         $variables->set('event', $input->eventdata);
-        return true;
+        return $input;
     }
 
     /**

--- a/tests/tool_dataflows_abort_test.php
+++ b/tests/tool_dataflows_abort_test.php
@@ -75,7 +75,6 @@ class tool_dataflows_abort_test extends \advanced_testcase {
         foreach ($engine->enginesteps as $step) {
             $this->assertEquals(test_engine::STATUS_ABORTED, $step->status);
             $this->assertTrue($step->iterator->is_finished());
-            $this->assertFalse($step->iterator->next($step));
         }
         foreach ($engine->flowcaps as $step) {
             $this->assertEquals(test_engine::STATUS_ABORTED, $step->status);

--- a/tests/tool_dataflows_flow_transformer_filter_test.php
+++ b/tests/tool_dataflows_flow_transformer_filter_test.php
@@ -1,0 +1,171 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows;
+
+use Symfony\Component\Yaml\Yaml;
+use tool_dataflows\local\execution\engine;
+
+/**
+ * Unit test for append file step.
+ *
+ * @package   tool_dataflows
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2023, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_dataflows_flow_transformer_filter_test extends \advanced_testcase {
+
+    /** Test data. */
+    const TEST_DATA = [
+        [ 'a' => '1', 'b' => 'a_1_b' ],
+        [ 'a' => '5', 'b' => 'a_9_b' ],
+        [ 'a' => 'x', 'b' => 'a_3_b' ],
+        [ 'a' => '0', 'b' => 'a_2_b' ],
+        [ 'a' => '0', 'b' => 'a_1_b' ],
+        [ 'a' => '0', 'b' => 'a_6_b' ],
+    ];
+
+    /** Input file name. */
+    const INPUT_FILE_NAME = 'input.json';
+
+    /** Output file name. */
+    const OUTPUT_FILE_NAME = 'output.json';
+
+    /** @var string  Base directory. */
+    private $basedir;
+
+    /**
+     * Set up before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+
+        // Set up list of files to be pumped through the flow loop.
+        $basedir = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
+        if (file_exists($basedir . self::OUTPUT_FILE_NAME)) {
+            unlink($basedir . self::OUTPUT_FILE_NAME);
+        }
+
+        $this->basedir = $basedir;
+    }
+
+
+    /**
+     * Tests appending to many files, declared 1:1.
+     *
+     * @dataProvider filter_provider
+     * @covers \tool_dataflows\local\step\flow_transformer_filter
+     * @param string $expr
+     * @param array $expected
+     */
+    public function test_filter(string $expr, array $expected) {
+
+        // Perform the test.
+        set_config('permitted_dirs', $this->basedir, 'tool_dataflows');
+        $dataflow = $this->make_dataflow($expr);
+
+        ob_start();
+        $engine = new engine($dataflow);
+        $engine->execute();
+        ob_get_clean();
+
+        $result = json_decode(file_get_contents($this->basedir . self::OUTPUT_FILE_NAME), true);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Provider function for test_filter().
+     *
+     * @return array[]
+     */
+    public function filter_provider() {
+        return [
+            [ 'record.a == 1', [
+                [ 'a' => '1', 'b' => 'a_1_b' ],
+            ]],
+            [ "record.a == '0'", [
+                [ 'a' => '0', 'b' => 'a_2_b' ],
+                [ 'a' => '0', 'b' => 'a_1_b' ],
+                [ 'a' => '0', 'b' => 'a_6_b' ],
+            ]],
+            [ "record.b >= 'a_3_b'", [
+                [ 'a' => '5', 'b' => 'a_9_b' ],
+                [ 'a' => 'x', 'b' => 'a_3_b' ],
+                [ 'a' => '0', 'b' => 'a_6_b' ],
+            ]],
+        ];
+    }
+
+    /**
+     * Creates a dataflow to test.
+     *
+     * @param string $expr Expression to add to filter step.
+     * @return dataflow
+     */
+    private function make_dataflow(string $expr): dataflow {
+        $namespace = '\\tool_dataflows\\local\\step\\';
+
+        $dataflow = new dataflow();
+        $dataflow->enabled = true;
+        $dataflow->name = 'dataflow';
+        $dataflow->save();
+
+        $setup = new step();
+        $setup->name = 'setup';
+        $setup->type = $namespace . 'connector_file_put_content';
+        $setup->config = Yaml::dump([
+            'path' => $this->basedir . self::INPUT_FILE_NAME,
+            'content' => json_encode(self::TEST_DATA),
+        ]);
+        $dataflow->add_step($setup);
+
+        $reader = new step();
+        $reader->name = 'reader';
+        $reader->type = $namespace . 'reader_json';
+        $reader->depends_on([$setup]);
+        $reader->config = Yaml::dump([
+            'pathtojson' => $this->basedir . self::INPUT_FILE_NAME,
+            'arrayexpression' => '',
+            'arraysortexpression' => '',
+            'sortorder' => '',
+        ]);
+        $dataflow->add_step($reader);
+
+        $filter = new step();
+        $filter->name = 'filter';
+        $filter->type = $namespace . 'flow_transformer_filter';
+        $filter->depends_on([$reader]);
+        $filter->config = Yaml::dump([
+            'filter' => $expr
+        ]);
+        $dataflow->add_step($filter);
+
+        $writer = new step();
+        $writer->name = 'writer';
+        $writer->type = $namespace . 'writer_stream';
+        $writer->depends_on([$filter]);
+        $writer->config = Yaml::dump([
+            'streamname' => $this->basedir . self::OUTPUT_FILE_NAME,
+            'format' => 'json',
+        ]);
+        $dataflow->add_step($writer);
+
+        return $dataflow;
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042400;
+$plugin->version = 2023042600;
 $plugin->release = 2022102600;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Resolves #715 #716

Remove boilerplate at beginning of dataflow_iterator::next(). Change iterator::next() signature to not return anything. Change dataflow_iterator::next() to set the current value to the return value of step::execute(). Fix steps to always return a value.
Fix flow_transformer_filter step
Add flow_transformer_filter unit test
Fix unit tests.