### PR TITLE
Refactor SQL execution to use prepared statements

### DIFF
--- a/classes/local/step/flow_sql.php
+++ b/classes/local/step/flow_sql.php
@@ -73,13 +73,13 @@ class flow_sql extends flow_step {
 
         // Construct the query.
         $variables = $this->get_variables();
-        $config = $variables->get('config');
-        $sql = $this->evaluate_expressions($config->sql);
+        $config = $variables->get_raw('config');
+        [$sql, $params] = $this->evaluate_expressions($config->sql);
 
         // Execute the query using get_records instead of get_record.
         // This is so we can expose the number of records returned which
         // can then be used by the dataflow in for e.g. a switch statement.
-        $records = $DB->get_records_sql($sql);
+        $records = $DB->get_records_sql($sql, $params);
 
         $variables->set('count', count($records));
 

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -76,19 +76,20 @@ class reader_sql extends reader_step {
      * @throws \moodle_exception
      */
     public function get_iterator(): iterator {
-        $query = $this->construct_query();
+        [$query, $params] = $this->construct_query();
 
-        return new class($this->enginestep, $query) extends dataflow_iterator {
+        return new class($this->enginestep, $query, $params) extends dataflow_iterator {
 
             /**
              * Create an instance of this class.
              *
              * @param  flow_engine_step $step
              * @param  string $query
+             * @param  array $params
              */
-            public function __construct(flow_engine_step $step, string $query) {
+            public function __construct(flow_engine_step $step, string $query, array $params) {
                 global $DB;
-                $input = $DB->get_recordset_sql($query);
+                $input = $DB->get_recordset_sql($query, $params);
                 parent::__construct($step, $input);
             }
 
@@ -108,10 +109,10 @@ class reader_sql extends reader_step {
      * expression linking to a variable / field that does NOT contain another
      * expression as this is not currently supported.
      *
-     * @return string
+     * @return array of SQL and parameters.
      * @throws \moodle_exception
      */
-    protected function construct_query(): string {
+    protected function construct_query(): array {
         // Get variables.
         $variables = $this->get_variables();
 
@@ -183,9 +184,7 @@ class reader_sql extends reader_step {
         }
 
         // Evalulate any remaining expressions as per normal.
-        $finalsql = $this->evaluate_expressions($finalsql);
-
-        return $finalsql;
+        return $this->evaluate_expressions($finalsql);
     }
 
     /**

--- a/tests/tool_dataflows_sql_reader_test.php
+++ b/tests/tool_dataflows_sql_reader_test.php
@@ -247,8 +247,8 @@ class tool_dataflows_sql_reader_test extends \advanced_testcase {
         $writer->depends_on([$reader]);
         $dataflow->add_step($writer);
 
-        $this->expectException('\moodle_exception');
-        $this->expectExceptionMessage(get_string('reader_sql:finalsql_not_string', 'tool_dataflows'));
+        // Array is not valid for String value field.
+        $this->expectException('TypeError');
 
         // Execute.
         ob_start();


### PR DESCRIPTION
SQL could be broken with values from a variable like `'`. Each variable is now processed as a parameter, and the whole SQL processed as a prepared statement