### PR TITLE
fix (gpg): show output on failure

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023051800;
-$plugin->release = 2022102600;
+$plugin->version = 2023052600;
+$plugin->release = 2023052600;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
This allows errors with the gpg command to show up in the output of a manual run, as well as log to the error log.

![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/2a9401de-0aa8-4bc1-93be-4af365c7369a)
