### PR TITLE
[#778] bugfix: register schedule when importing cron steps

### DIFF
--- a/classes/step.php
+++ b/classes/step.php
@@ -647,6 +647,30 @@ class step extends persistent {
     }
 
     /**
+     * Called after updating.
+     *
+     * Triggers steptype on_save callback and dataflow on_steps_save callback.
+     *
+     * @param bool $result True if the delete was successful.
+     */
+    protected function after_update($result) {
+        if ($result) {
+            $this->get_steptype()->on_save();
+            $this->get_dataflow()->on_steps_save();
+        }
+    }
+
+    /**
+     * Called after creating.
+     *
+     * Triggers steptype on_save callback and dataflow on_steps_save callback.
+     */
+    protected function after_create() {
+        $this->get_steptype()->on_save();
+        $this->get_dataflow()->on_steps_save();
+    }
+
+    /**
      * Sets the validated flag to false, such that validation can take place on
      * the persistent again.
      */

--- a/tests/fixtures/sample-cron.yml
+++ b/tests/fixtures/sample-cron.yml
@@ -1,0 +1,24 @@
+name: Example dataflow with Cron trigger
+
+steps:
+  cron:
+    name: cron
+    type: tool_dataflows\local\step\trigger_cron
+    config:
+      minute: '*'
+      hour: '*'
+      day: '*'
+      month: '*'
+      dayofweek: '*'
+  sql_reader:
+    name: 'SQL reader'
+    depends_on: cron
+    type: tool_dataflows\local\step\reader_sql
+    config:
+      sql: 'SELECT id FROM {user}'
+      counterfield: ''
+      countervalue: ''
+  debugging_writer:
+    name: 'Debugging writer'
+    depends_on: sql_reader
+    type: tool_dataflows\local\step\writer_debugging


### PR DESCRIPTION
Closes #778 

-  <strike>Since we cannot override the persistant's `save` function, I made a new function `save_step` which calls both `save()` and any `on_save()` callbacks</strike>
-  <strike>Hopefully this means in the future we don't run into this issue for anything else that uses this callback, as long as we are using `save_step`</strike>

- Have just added hook callbacks for after updating and after creating to trigger the steptype and dataflow save callbacks.
- Added unit tests for the cron trigger to unit test this as well

**Manual testing:**

- Upload the attached yml file [Test_flow_2_21313123_20230606_0157.txt](https://github.com/catalyst/moodle-tool_dataflows/files/11659409/Test_flow_2_21313123_20230606_0157.txt)
- Check that a record was made in `mdl_tool_dataflows_schedule`



