### PR TITLE
768 fix concurrency

### DIFF
--- a/classes/local/event_processor.php
+++ b/classes/local/event_processor.php
@@ -145,10 +145,7 @@ class event_processor {
                     self::add_triggered_event($dataflow->id, $step->id, json_encode($eventdata));
 
                     // Create adhoc task to execute.
-                    $record = (object) [
-                        'dataflowid' => $dataflow->id,
-                    ];
-                    \tool_dataflows\task\process_dataflow_ad_hoc::execute_from_record($record);
+                    \tool_dataflows\task\process_dataflow_ad_hoc::queue_adhoctask($dataflow);
 
                     break;
                 case self::EXECUTE_ADHOCQUEUED:

--- a/classes/task/process_dataflows.php
+++ b/classes/task/process_dataflows.php
@@ -50,15 +50,10 @@ class process_dataflows extends \core\task\scheduled_task {
 
         $dataflowrecords = array_merge($scheduledrecords, $eventrecords);
 
-        $firstdataflowrecord = array_shift($dataflowrecords);
-        if (isset($firstdataflowrecord)) {
-            // Create ad-hoc tasks for all but the first dataflow shifted earlier.
-            foreach ($dataflowrecords as $dataflowrecord) {
-                process_dataflow_ad_hoc::execute_from_record($dataflowrecord);
-            }
-
-            // Run a single dataflow immediately.
-            self::execute_dataflow($firstdataflowrecord->dataflowid);
+        // Queue all dataflows to be run as adhoc tasks.
+        foreach ($dataflowrecords as $record) {
+            $dataflow = new dataflow($record->dataflowid);
+            process_dataflow_ad_hoc::queue_adhoctask($dataflow);
         }
     }
 

--- a/tests/tool_dataflows_flow_transformer_alter_test.php
+++ b/tests/tool_dataflows_flow_transformer_alter_test.php
@@ -139,19 +139,19 @@ class tool_dataflows_flow_transformer_alter_test extends \advanced_testcase {
         $dataflow->name = 'dataflow';
         $dataflow->save();
 
-        $setup = new step();
-        $setup->name = 'setup';
-        $setup->type = $namespace . 'connector_file_put_content';
-        $setup->config = Yaml::dump([
+        $setupconnector = new step();
+        $setupconnector->name = 'setup';
+        $setupconnector->type = $namespace . 'connector_file_put_content';
+        $setupconnector->config = Yaml::dump([
             'path' => $this->basedir . self::INPUT_FILE_NAME,
             'content' => json_encode($data),
         ]);
-        $dataflow->add_step($setup);
+        $dataflow->add_step($setupconnector);
 
         $reader = new step();
         $reader->name = 'reader';
         $reader->type = $namespace . 'reader_json';
-        $reader->depends_on([$setup]);
+        $reader->depends_on([$setupconnector]);
         $reader->config = Yaml::dump([
             'pathtojson' => $this->basedir . self::INPUT_FILE_NAME,
             'arrayexpression' => '',

--- a/tests/tool_dataflows_json_reader_test.php
+++ b/tests/tool_dataflows_json_reader_test.php
@@ -35,7 +35,6 @@ require_once(dirname(__FILE__) . '/../lib.php');
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_json_reader_test extends \advanced_testcase {
-
     /**
      * Set up before each test
      */
@@ -116,7 +115,7 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
      * Creates the base contents of the reader file
      */
     public function set_initial_test_data() {
-        $users = [
+        $this->users = [
             (object) ['id' => '2', 'userdetails' => (object) ['firstname' => 'John', 'lastname' => 'Doe', 'name' => 'Name2']],
             (object) ['id' => '1', 'userdetails' => (object) ['firstname' => 'Bob', 'lastname' => 'Smith', 'name' => 'Name1']],
             (object) ['id' => '3', 'userdetails' => (object) ['firstname' => 'Foo', 'lastname' => 'Bar', 'name' => 'Name3']],
@@ -124,7 +123,7 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
 
         $json = json_encode((object) [
             'data' => (object) [
-                'list' => ['users' => $users],
+                'list' => ['users' => $this->users],
             ],
             'modified' => [1654058940],
             'errors' => [],
@@ -145,11 +144,7 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
         [$dataflow, $reader, $writer] = [$this->dataflow, $this->reader, $this->writer];
 
         // Test unsorted array.
-        $users = [
-            (object) ['id' => '2', 'userdetails' => (object) ['firstname' => 'John', 'lastname' => 'Doe', 'name' => 'Name2']],
-            (object) ['id' => '1', 'userdetails' => (object) ['firstname' => 'Bob', 'lastname' => 'Smith', 'name' => 'Name1']],
-            (object) ['id' => '3', 'userdetails' => (object) ['firstname' => 'Foo', 'lastname' => 'Bar', 'name' => 'Name3']],
-        ];
+        $users = $this->users;
 
         $json = json_encode((object) [
             'data' => (object) [
@@ -205,9 +200,9 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
         ]);
 
         $sorteduserarray = [
-            (object) ['id' => '1', 'userdetails' => (object) ['firstname' => 'Bob', 'lastname' => 'Smith', 'name' => 'Name1']],
-            (object) ['id' => '3', 'userdetails' => (object) ['firstname' => 'Foo', 'lastname' => 'Bar', 'name' => 'Name3']],
-            (object) ['id' => '2', 'userdetails' => (object) ['firstname' => 'John', 'lastname' => 'Doe', 'name' => 'Name2']],
+            $this->users[1],
+            $this->users[2],
+            $this->users[0]
         ];
 
         $writer->config = Yaml::dump([
@@ -284,9 +279,9 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
         ]);
 
         $reversesorteduserarray = [
-            (object) ['id' => '2', 'userdetails' => (object) ['firstname' => 'John', 'lastname' => 'Doe', 'name' => 'Name2']],
-            (object) ['id' => '3', 'userdetails' => (object) ['firstname' => 'Foo', 'lastname' => 'Bar', 'name' => 'Name3']],
-            (object) ['id' => '1', 'userdetails' => (object) ['firstname' => 'Bob', 'lastname' => 'Smith', 'name' => 'Name1']],
+            $this->users[0],
+            $this->users[2],
+            $this->users[1]
         ];
 
         $writer->config = Yaml::dump([

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -55,7 +55,7 @@ class tool_dataflows_test extends \advanced_testcase {
      * @covers \tool_dataflows\dataflow
      */
     public function test_creating_empty_dataflow(): void {
-        $name = 'test dataflow';
+        $name = 'test empty dataflow';
         $desc = 'some description';
         $persistent = new \tool_dataflows\dataflow();
         $persistent
@@ -89,25 +89,25 @@ class tool_dataflows_test extends \advanced_testcase {
      * @covers \tool_dataflows\dataflow::get_dotscript
      */
     public function test_dependent_steps_and_dot_script(): void {
-        $name = 'test dataflow';
+        $name = 'test dependent steps dataflow';
         $dataflow = new \tool_dataflows\dataflow();
         $dataflow
             ->set('name', $name)
             ->create();
 
         $stepone = new \tool_dataflows\step();
-        $stepone->name = 'step1';
+        $stepone->name = 'stepa';
         $stepone->type = local\execution\array_in_type::class;
         $dataflow->add_step($stepone);
 
         $steptwo = new \tool_dataflows\step();
-        $steptwo->name = 'step2';
+        $steptwo->name = 'stepb';
         $steptwo->type = step\writer_debugging::class;
         $steptwo->depends_on([$stepone]);
         $dataflow->add_step($steptwo);
 
         $stepthree = new \tool_dataflows\step();
-        $stepthree->name = 'step3';
+        $stepthree->name = 'stepc';
         $stepthree->type = step\writer_debugging::class;
         $stepthree->depends_on([$steptwo]);
         $dataflow->add_step($stepthree);
@@ -133,7 +133,7 @@ class tool_dataflows_test extends \advanced_testcase {
      * @covers \tool_dataflows\dataflow::validate_dataflow
      */
     public function test_dataflow_validation(): void {
-        $name = 'test dataflow';
+        $name = 'test dataflow validation';
         $dataflow = new \tool_dataflows\dataflow();
         $dataflow
             ->set('name', $name)

--- a/tests/tool_dataflows_workflow_state_test.php
+++ b/tests/tool_dataflows_workflow_state_test.php
@@ -73,22 +73,22 @@ class tool_dataflows_workflow_state_test extends \advanced_testcase {
         $dataflow->enabled = true;
         $dataflow->save();
 
-        $reader = new step();
-        $reader->name = 'reader';
-        $reader->type = 'tool_dataflows\local\step\reader_sql';
+        $sqlreader = new step();
+        $sqlreader->name = 'reader';
+        $sqlreader->type = 'tool_dataflows\local\step\reader_sql';
 
         // Set the SQL query via a YAML config string.
-        $reader->config = Yaml::dump([
+        $sqlreader->config = Yaml::dump([
             'sql' => $sql,
             'counterfield' => 'value',
             'countervalue' => '',
         ]);
-        $dataflow->add_step($reader);
+        $dataflow->add_step($sqlreader);
 
         $writer = new step();
         $writer->name = 'writer';
         $writer->type = 'tool_dataflows\local\step\writer_debugging';
-        $writer->depends_on([$reader]);
+        $writer->depends_on([$sqlreader]);
         $dataflow->add_step($writer);
 
         // Create engine.

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023052900;
-$plugin->release = 2023052900;
+$plugin->version = 2023060800;
+$plugin->release = 2023060800;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Closes #768 

## Changes
- Now when scheduled task is run, it simply makes an adhoc task for each dataflow. It does not try to run one in the same thread - this is much cleaner and simpler.
- The adhoc tasks now only take in a dataflow id - no other custom data is allowed. This ensures they can be de-duplicated
- Will de-duplicate adhoc tasks based on concurrency settings

## Testing
-  Covered by unit tests.