### PR TITLE
#783 improve directory file list step

### DIFF
--- a/classes/local/step/directory_file_list_trait.php
+++ b/classes/local/step/directory_file_list_trait.php
@@ -137,11 +137,11 @@ trait directory_file_list_trait {
             $this->get_engine()->abort($error);
         }
 
-        $path = $path . DIRECTORY_SEPARATOR . $pattern;
-        $filelist = glob($path);
+        $pathpattern = $path . DIRECTORY_SEPARATOR . $pattern;
+        $filelist = glob($pathpattern, GLOB_BRACE);
 
         // Apply filter for excluding directories/folders.
-        // This is not related to recursive lookups in any way
+        // This is not related to recursive lookups in any way.
         $filelist = array_filter($filelist, function ($pathname) use ($includedir) {
             $filename = basename($pathname);
             if ($filename === '.' || $filename === '..') {

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -533,18 +533,23 @@ $string['flow_copy_file:copy_failed'] = 'Failed to copy {$a->from} to {$a->to}';
 $string['connector_directory_file_count:path'] = 'Path to directory';
 
 // Directory file list.
-$string['directory_file_list:pattern'] = 'File pattern';
-$string['directory_file_list:sort'] = 'Sort';
-$string['directory_file_list:size'] = 'Largest to smallest';
-$string['directory_file_list:size_reverse'] = 'Smallest to larget';
-$string['directory_file_list:time'] = 'Latest to earliest';
-$string['directory_file_list:time_reverse'] = 'Earliest to latest';
-$string['directory_file_list:subdirectories'] = 'Include sub-directories?';
-$string['directory_file_list:offset'] = 'Offset';
-$string['directory_file_list:limit'] = 'Limit';
-$string['directory_file_list:filenames'] = 'List of filenames.';
+$string['directory_file_list:absolutepath'] = 'absolutepath';
 $string['directory_file_list:alpha'] = 'Alphabetical (A->Z)';
 $string['directory_file_list:alpha_reverse'] = 'Reverse alphabetical (Z->A)';
+$string['directory_file_list:basename'] = 'Base Name';
+$string['directory_file_list:filenames'] = 'List of filenames.';
+$string['directory_file_list:limit'] = 'Limit';
+$string['directory_file_list:offset'] = 'Offset';
+$string['directory_file_list:pattern'] = 'File pattern';
+$string['directory_file_list:relativepath'] = 'Relative Path';
+$string['directory_file_list:returnvalue'] = 'Return Value';
+$string['directory_file_list:returnvalue'] = 'Return Value';
+$string['directory_file_list:size'] = 'Largest to smallest';
+$string['directory_file_list:size_reverse'] = 'Smallest to larget';
+$string['directory_file_list:sort'] = 'Sort';
+$string['directory_file_list:subdirectories'] = 'Include sub-directories?';
+$string['directory_file_list:time'] = 'Latest to earliest';
+$string['directory_file_list:time_reverse'] = 'Earliest to latest';
 
 // Variables.
 $string['variables:assign_object_to_value'] = 'Attempting to assign an object to a value node for \'{$a}\'.';

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -543,7 +543,6 @@ $string['directory_file_list:offset'] = 'Offset';
 $string['directory_file_list:pattern'] = 'File pattern';
 $string['directory_file_list:relativepath'] = 'Relative Path';
 $string['directory_file_list:returnvalue'] = 'Return Value';
-$string['directory_file_list:returnvalue'] = 'Return Value';
 $string['directory_file_list:size'] = 'Largest to smallest';
 $string['directory_file_list:size_reverse'] = 'Smallest to larget';
 $string['directory_file_list:sort'] = 'Sort';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023062700;
-$plugin->release = 2023060800;
+$plugin->version = 2023062800;
+$plugin->release = 2023062800;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
- feat(directory-file-list): add different return value formats: absolutepath, basename, relativepath
- feat(file-directory-list): add glob braces for multi pattern support

Relative path output with glob brace support, pattern of `{*,**/*}`
![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/845022a0-ec0a-4de7-904f-97e6f9e63240)

Relative path output with pattern `**/*`
![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/97dee2b4-7af1-44ca-8788-94ae8609a960)

Absoulte path output, pattern `**/*`
![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/202c3cd8-fc04-452d-8bce-d572a039d32c)

Basename (which is the default), pattern `**/*`
![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/3775e69f-263f-4bc6-b144-afc3ccb5f577)

