### PR TITLE
fix: cast run's timestamp to int for display

### DIFF
--- a/view-run.php
+++ b/view-run.php
@@ -99,12 +99,12 @@ $duration = number_format($run->timefinished - $run->timestarted, 4);
 $secsstr = get_string('secs');
 $data = [
     'field_timestarted' => date_format_string(
-        $run->timestarted,
+        (int) $run->timestarted,
         get_string('strftimedatetimeaccurate', 'tool_dataflows'),
         $defaulttimezone
     ),
     'field_timefinished' => date_format_string(
-        $run->timefinished,
+        (int) $run->timefinished,
         get_string('strftimedatetimeaccurate', 'tool_dataflows'),
         $defaulttimezone
     ),


### PR DESCRIPTION
![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/72946e64-0ec8-4d05-a70d-15fea0c9936b)

Resolves #787 