### PR TITLE
feat: add webservice trigger

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -695,4 +695,20 @@ class dataflow extends persistent {
     public function escape_dot(string $stringtoescape): string {
         return addslashes($stringtoescape);
     }
+
+    /**
+     * Returns whether or not the dataflow contains a particular trigger step (by class)
+     *
+     * @param   string $classname of the matching trigger
+     * @return  bool true if the trigger is found in the dataflow
+     */
+    public function has_trigger_step(string $classname): bool {
+        $steps = $this->steps;
+        foreach ($steps as $step) {
+            if ($step->type === $classname) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/classes/external/trigger_dataflow.php
+++ b/classes/external/trigger_dataflow.php
@@ -20,6 +20,7 @@ use external_function_parameters;
 use external_single_structure;
 use external_value;
 use tool_dataflows\dataflow;
+use tool_dataflows\local\step\trigger_webservice;
 use tool_dataflows\task\process_dataflow_ad_hoc;
 
 /**
@@ -62,10 +63,16 @@ class trigger_dataflow extends \external_api {
      * @param array $dataflow array of dataflow run information.
      * @return array of newly created groups
      */
-    public static function execute($dataflow) {
+    public static function execute($dataflow): array {
         $params = self::validate_parameters(self::execute_parameters(), ['dataflow' => $dataflow]);
 
         $dataflow = new dataflow($params['dataflow']['id']);
+
+        // Confirm the dataflow contains a webservice trigger step.
+        if (!$dataflow->has_trigger_step(trigger_webservice::class)) {
+            throw new \invalid_parameter_exception('The dataflow does not contain a webservice trigger step.');
+        }
+
         process_dataflow_ad_hoc::queue_adhoctask($dataflow);
 
         if (empty($dataflow->get('id'))) {

--- a/classes/external/trigger_dataflow.php
+++ b/classes/external/trigger_dataflow.php
@@ -1,0 +1,77 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_dataflows\external;
+
+use external_function_parameters;
+use external_single_structure;
+use external_value;
+use tool_dataflows\dataflow;
+use tool_dataflows\task\process_dataflow_ad_hoc;
+
+/**
+ * Trigger dataflow webservice function.
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2023
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class trigger_dataflow extends \external_api {
+
+    /**
+     * Returns description of method parameters
+     * @return external_function_parameters
+     */
+    public static function execute_parameters() {
+        return new external_function_parameters([
+            'dataflow' => new external_single_structure([
+                'id' => new external_value(PARAM_INT, 'dataflow record id'),
+            ])
+        ]);
+    }
+
+    /**
+     * Returns description of method return values
+     * @return external_single_structure
+     */
+    public static function execute_returns() {
+        return new external_single_structure([
+            'id' => new external_value(PARAM_INT, 'dataflow record id'),
+        ]);
+    }
+
+    /**
+     * Trigger a dataflow run
+     *
+     * Currently it only supports asynchronous execution.
+     *
+     * @param array $dataflow array of dataflow run information.
+     * @return array of newly created groups
+     */
+    public static function execute($dataflow) {
+        $params = self::validate_parameters(self::execute_parameters(), ['dataflow' => $dataflow]);
+
+        $dataflow = new dataflow($params['dataflow']['id']);
+        process_dataflow_ad_hoc::queue_adhoctask($dataflow);
+
+        if (empty($dataflow->get('id'))) {
+            throw new \invalid_parameter_exception('Unable to load the dataflow requested.');
+        }
+
+        return ['id' => $dataflow->id];
+    }
+}

--- a/classes/local/step/trigger_webservice.php
+++ b/classes/local/step/trigger_webservice.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,22 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_dataflows\local\step;
+
 /**
- * Version
+ * Webservice trigger step
  *
- * @package   tool_dataflows
- * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
- * @copyright  2022, Catalyst IT
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2023
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-defined('MOODLE_INTERNAL') || die();
-
-$plugin->version = 2023063000;
-$plugin->release = 2023063000;
-$plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
-$plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.
-// TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.
-$plugin->component = 'tool_dataflows';
-$plugin->maturity = MATURITY_ALPHA;
-$plugin->dependencies = [];
+class trigger_webservice extends trigger_step {
+}

--- a/db/services.php
+++ b/db/services.php
@@ -17,10 +17,10 @@
 /**
  * Web Services.
  *
- * @package    tool_dataflows
- * @author     Kevin Pham <kevinpham@catalyst-au.net>
- * @copyright  Catalyst IT, 2023
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package   tool_dataflows
+ * @author    Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright Catalyst IT, 2023
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
@@ -40,7 +40,20 @@ $functions = [
         // Whether the service is available for use in AJAX calls from the web.
         'ajax'        => false,
 
+        // Default name per the moodle docs (backwards compatibility support).
+        'methodname' => 'execute',
+
         // An optional list of services where the function will be included.
-        'services' => []
+        'services' => ['dataflow_service'],
     ],
+];
+
+// We define the services to install as pre-build services. A pre-build service is not editable by administrator.
+$services = [
+    'Dataflow service' => [
+        'enabled' => 1,
+        'functions' => ['tool_dataflows_trigger_dataflow'],
+        'restrictedusers' => 0,
+        'shortname' => 'dataflow_service',
+    ]
 ];

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Web Services.
+ *
+ * @package    tool_dataflows
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2023
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$functions = [
+    // The name of your web service function, as discussed above.
+    'tool_dataflows_trigger_dataflow' => [
+        // The name of the namespaced class that the function is located in.
+        'classname'   => 'tool_dataflows\external\trigger_dataflow',
+
+        // A brief, human-readable, description of the web service function.
+        'description' => 'Triggers a dataflow.',
+
+        // Options include read, and write.
+        'type'        => 'write',
+
+        // Whether the service is available for use in AJAX calls from the web.
+        'ajax'        => false,
+
+        // An optional list of services where the function will be included.
+        'services' => []
+    ],
+];

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -163,6 +163,7 @@ $string['step_name_reader_directory_file_list'] = 'Directory file list reader';
 $string['step_name_reader_json'] = 'JSON reader';
 $string['step_name_reader_sql'] = 'SQL reader';
 $string['step_name_trigger_cron'] = 'Cron';
+$string['step_name_trigger_webservice'] = 'Webservice';
 $string['step_name_writer_debugging'] = 'Debugging writer';
 $string['step_name_writer_stream'] = 'Stream writer';
 $string['step_name_trigger_event'] = 'Moodle event';

--- a/lib.php
+++ b/lib.php
@@ -92,9 +92,10 @@ function tool_dataflows_step_types() {
         new step\reader_json,
         new step\reader_sql,
         new step\trigger_cron,
+        new step\trigger_event,
+        new step\trigger_webservice,
         new step\writer_debugging,
         new step\writer_stream,
-        new step\trigger_event,
         new step\flow_sql,
     ];
 }


### PR DESCRIPTION
Currently adds the dataflow to the adhoc task queue, and does not process it in place. This is typically the recommended default for api calls.

Closes #790
