### PR TITLE
[#799] fix: flow sql step sets data as objects always

### DIFF
--- a/classes/local/step/flow_logic_switch.php
+++ b/classes/local/step/flow_logic_switch.php
@@ -28,7 +28,6 @@ namespace tool_dataflows\local\step;
 use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\execution\iterators\dataflow_iterator;
 use tool_dataflows\local\execution\iterators\iterator;
-use tool_dataflows\parser;
 
 /**
  * Flow logic: switch
@@ -214,7 +213,6 @@ class flow_logic_switch extends flow_logic_step {
                     // the position of the step that is 'pulling' on this one for
                     // efficiency.
                     // See issue #347 for more details.
-                    $parser = parser::get_parser();
                     $casefailures = 0;
                     foreach ($this->cases as $caseindex => $case) {
                         $result = (bool) $this->stepvars->evaluate('${{ ' . $case . ' }}');

--- a/classes/local/step/flow_sql.php
+++ b/classes/local/step/flow_sql.php
@@ -84,6 +84,7 @@ class flow_sql extends flow_step {
 
         // Matches[0] contains the match. Fallthrough to default on no match.
         $token = $matches[0] ?? '';
+        $emptydefault = new \stdClass();
 
         switch($token) {
             case 'SELECT':
@@ -91,17 +92,19 @@ class flow_sql extends flow_step {
                 // This is so we can expose the number of records returned which
                 // can then be used by the dataflow in for e.g. a switch statement.
                 $records = $DB->get_records_sql($sql, $params);
+
                 $variables->set('count', count($records));
                 $invalidnum = ($records === false || count($records) !== 1);
-                $data = $invalidnum ? [] : array_pop($records);
+                $data = $invalidnum ? $emptydefault : array_pop($records);
                 $variables->set('data', $data);
                 break;
             default:
                 // Default to execute.
                 $success = $DB->execute($sql, $params);
+
                 // We can't really do anything with the response except check for success.
                 $variables->set('count', (int) $success);
-                $variables->set('data', []);
+                $variables->set('data', $emptydefault);
                 break;
         }
 

--- a/tests/tool_dataflows_flow_sql_test.php
+++ b/tests/tool_dataflows_flow_sql_test.php
@@ -225,7 +225,7 @@ class tool_dataflows_flow_sql_test extends \advanced_testcase {
 
         $variables = $engine->get_variables_root()->get();
         $lastiterationflow = $variables->steps->flow;
-        $this->assertEquals([], $lastiterationflow->data);
+        $this->assertEquals([], (array) $lastiterationflow->data);
         $this->assertEquals(0, $lastiterationflow->count);
     }
 
@@ -252,7 +252,7 @@ class tool_dataflows_flow_sql_test extends \advanced_testcase {
 
         $variables = $engine->get_variables_root()->get();
         $lastiterationflow = $variables->steps->flow;
-        $this->assertEquals([], $lastiterationflow->data);
+        $this->assertEquals([], (array) $lastiterationflow->data);
         $this->assertEquals($numcourses, $lastiterationflow->count);
     }
 

--- a/tests/tool_dataflows_reader_csv_test.php
+++ b/tests/tool_dataflows_reader_csv_test.php
@@ -152,8 +152,11 @@ class tool_dataflows_reader_csv_test extends \advanced_testcase {
         $engine = new engine($dataflow);
         $this->expectExceptionMessage(get_string('writer_stream:failed_to_open_stream',
             'tool_dataflows', $engine->resolve_path($path)));
-        $engine->execute();
-        ob_get_clean();
+        try {
+            $engine->execute();
+        } finally {
+            ob_get_clean();
+        }
     }
 
     /**


### PR DESCRIPTION
This is set to work with the limitations of the variable node tree, where a node cannot change its type from a value node to an object node. Setting it always as an object allows it to sometimes contain the record returned, and sometimes being an empty object (when no results are found)

Resolves #799
