### PR TITLE
No longer using externallib.php

### DIFF
--- a/classes/local/step/flow_web_service.php
+++ b/classes/local/step/flow_web_service.php
@@ -18,13 +18,10 @@ namespace tool_dataflows\local\step;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir . '/externallib.php');
-
 use core_user;
 use core\session\manager;
-use external_api;
+use core_external\external_api;
 use moodle_exception;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
 use Throwable;
 use tool_dataflows\parser;

--- a/tests/tool_dataflows_web_service_flow_test.php
+++ b/tests/tool_dataflows_web_service_flow_test.php
@@ -19,10 +19,7 @@ namespace tool_dataflows;
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
-require_once($CFG->libdir.'/externallib.php');
 require_once(__DIR__ . '/application_trait.php');
-
-
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
@@ -38,6 +35,7 @@ use tool_dataflows\step;
  * @author    Ghaly Marc-Alexandre <marc-alexandreghaly@catalyst-ca.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @runInSeparateProcess
  */
 class tool_dataflows_web_service_flow_test extends \advanced_testcase {
     use application_trait;


### PR DESCRIPTION
but using core_external\external_api
This addresses #796

It should be given a new branch e.g. MOODLE_402_STABLE.
