### PR TITLE
feat: config to overwrite headers for csv reader

### DIFF
--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -357,6 +357,8 @@ $string['reader_csv:path'] = 'Path to CSV file';
 $string['reader_csv:delimiter'] = 'Delimiter';
 $string['reader_csv:headers'] = 'Headers';
 $string['reader_csv:headers_help'] = 'If populated, then this will act as the header to map field to keys. If left blank, it will be populated automatically using the first read row.';
+$string['reader_csv:overwriteheaders'] = 'Overwrite existing headers';
+$string['reader_csv:overwriteheaders_help'] = 'If checked, the headers supplied above will be used instead of the ones in the file, effectively ignoring the first row.';
 
 // Reader JSON.
 $string['reader_json:arrayexpression_help'] = 'Nested array to extract from JSON. For example, {$a->expression} will return the users array from the following JSON (If empty it is assumed the starting point of the JSON file is an array):{$a->jsonexample}';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023070500;
-$plugin->release = 2023070500;
+$plugin->version = 2023071400;
+$plugin->release = 2023071400;
 $plugin->requires = 2017051500;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [35, 401];    // Available as of Moodle 3.9.0 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Resolves #807

![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/9d4350b3-d773-4085-99d1-822344fe4706)
This is what it looks like.

Added a test to ensure it works as expected.
