### PR TITLE
[#809] fix: SQL input field width to improve UX for larger queries

### DIFF
--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -140,6 +140,24 @@ class step_form extends \core\form\persistent {
     }
 
     /**
+     * Allow steps to setup the form depending on current values.
+     *
+     * This method is called after definition(), data submission and set_data().
+     * All form setup that is dependent on form values should go in here.
+     */
+    public function definition_after_data() {
+        $mform = $this->_form;
+        $data = $this->get_default_data();
+
+        $persistent = $this->get_persistent();
+        $type = $data->type ?? null;
+        if (isset($persistent->steptype) || (isset($type) && class_exists($type))) {
+            $steptype = $persistent->steptype ?? new $type();
+            $steptype->form_definition_after_data($mform, $data);
+        }
+    }
+
+    /**
      * Prepares and returns an array of dependson options
      *
      * @return  array of options this step could depend on

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -299,6 +299,18 @@ abstract class base_step {
     }
 
     /**
+     * Allow steps to setup the form depending on current values.
+     *
+     * This method is called after definition(), data submission and set_data().
+     * All form setup that is dependent on form values should go in here.
+     *
+     * @param \MoodleQuickForm $mform
+     * @param \stdClass $data
+     */
+    public function form_definition_after_data(\MoodleQuickForm &$mform, \stdClass $data) {
+    }
+
+    /**
      * Sets the default types for each input field defined
      *
      * This is mostly defined upfront and unlikely to change, and will show the following if not set:

--- a/classes/local/step/flow_sql.php
+++ b/classes/local/step/flow_sql.php
@@ -57,8 +57,37 @@ class flow_sql extends flow_step {
          LIMIT 10";
         $sqlexamples = \html_writer::tag('pre', trim($sqlexample, " \t\r\0\x0B"));
         $mform->addElement('textarea', 'config_sql', get_string('flow_sql:sql', 'tool_dataflows'),
-            ['rows' => 20, 'style' => 'font: 87.5% monospace; width: 100%; max-width: 100%']);
+            ['max_rows' => 40, 'rows' => 5, 'style' => 'font: 87.5% monospace; width: 100%; max-width: 100%']);
         $mform->addElement('static', 'config_sql_help', '', get_string('flow_sql:sql_help', 'tool_dataflows', $sqlexamples));
+    }
+
+    /**
+     * Allow steps to setup the form depending on current values.
+     *
+     * This method is called after definition(), data submission and set_data().
+     * All form setup that is dependent on form values should go in here.
+     *
+     * @param \MoodleQuickForm $mform
+     * @param \stdClass $data
+     */
+    public function form_definition_after_data(\MoodleQuickForm &$mform, \stdClass $data) {
+        // Validate the data.
+        $sqllinecount = count(explode(PHP_EOL, trim($data->config_sql)));
+
+        // Get the element.
+        $element = $mform->getElement('config_sql');
+
+        // Update the element height based on min/max settings, but preserve
+        // other existing rules.
+        $attributes = $element->getAttributes();
+
+        // Set the rows at a minimum to the predefined amount in
+        // form_add_custom_inputs, and expand as content grows up to a maximum.
+        $attributes['rows'] = min(
+            $attributes['max_rows'],
+            max($attributes['rows'], $sqllinecount)
+        );
+        $element->setAttributes($attributes);
     }
 
     /**

--- a/classes/local/step/flow_sql.php
+++ b/classes/local/step/flow_sql.php
@@ -57,7 +57,7 @@ class flow_sql extends flow_step {
          LIMIT 10";
         $sqlexamples = \html_writer::tag('pre', trim($sqlexample, " \t\r\0\x0B"));
         $mform->addElement('textarea', 'config_sql', get_string('flow_sql:sql', 'tool_dataflows'),
-            ['cols' => 50, 'rows' => 7, 'style' => 'font: 87.5% monospace;']);
+            ['rows' => 20, 'style' => 'font: 87.5% monospace; width: 100%; max-width: 100%']);
         $mform->addElement('static', 'config_sql_help', '', get_string('flow_sql:sql_help', 'tool_dataflows', $sqlexamples));
     }
 

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -208,7 +208,7 @@ ORDER BY id ASC
         $sqlexamples = \html_writer::tag('pre', trim($sqlexamples, " \t\r\0\x0B"));
 
         $mform->addElement('textarea', 'config_sql', get_string('reader_sql:sql', 'tool_dataflows'),
-            ['cols' => 50, 'rows' => 7, 'style' => 'font: 87.5% monospace;']);
+            ['rows' => 20, 'style' => 'font: 87.5% monospace; width: 100%; max-width: 100%']);
         $mform->addElement('static', 'config_sql_help', '', get_string('reader_sql:sql_help', 'tool_dataflows', $sqlexamples));
 
         // Counter field.

--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -208,7 +208,7 @@ ORDER BY id ASC
         $sqlexamples = \html_writer::tag('pre', trim($sqlexamples, " \t\r\0\x0B"));
 
         $mform->addElement('textarea', 'config_sql', get_string('reader_sql:sql', 'tool_dataflows'),
-            ['rows' => 20, 'style' => 'font: 87.5% monospace; width: 100%; max-width: 100%']);
+            ['max_rows' => 40, 'rows' => 5, 'style' => 'font: 87.5% monospace; width: 100%; max-width: 100%']);
         $mform->addElement('static', 'config_sql_help', '', get_string('reader_sql:sql_help', 'tool_dataflows', $sqlexamples));
 
         // Counter field.
@@ -218,6 +218,35 @@ ORDER BY id ASC
         // Counter value.
         $mform->addElement('text', 'config_countervalue', get_string('reader_sql:countervalue', 'tool_dataflows'));
         $mform->addElement('static', 'config_countervalue_help', '', get_string('reader_sql:countervalue_help', 'tool_dataflows'));
+    }
+
+    /**
+     * Allow steps to setup the form depending on current values.
+     *
+     * This method is called after definition(), data submission and set_data().
+     * All form setup that is dependent on form values should go in here.
+     *
+     * @param \MoodleQuickForm $mform
+     * @param \stdClass $data
+     */
+    public function form_definition_after_data(\MoodleQuickForm &$mform, \stdClass $data) {
+        // Validate the data.
+        $sqllinecount = count(explode(PHP_EOL, trim($data->config_sql)));
+
+        // Get the element.
+        $element = $mform->getElement('config_sql');
+
+        // Update the element height based on min/max settings, but preserve
+        // other existing rules.
+        $attributes = $element->getAttributes();
+
+        // Set the rows at a minimum to the predefined amount in
+        // form_add_custom_inputs, and expand as content grows up to a maximum.
+        $attributes['rows'] = min(
+            $attributes['max_rows'],
+            max($attributes['rows'], $sqllinecount)
+        );
+        $element->setAttributes($attributes);
     }
 
     /**


### PR DESCRIPTION
Resolves #809

Before:
![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/3e1a9148-7884-495b-81fb-77b8e8c34c81)

After:

![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/aa26d3b7-42d7-4b42-bc0e-d11882673048)
