### PR TITLE
fix totara unit tests

### DIFF
--- a/tests/application_trait.php
+++ b/tests/application_trait.php
@@ -44,7 +44,7 @@ trait application_trait {
      * @return  string mock url to use
      */
     public function get_mock_url(string $path): string {
-        return 'http://download.moodle.org/unittest'.$path;
+        return 'https://download.moodle.org/unittest'.$path;
     }
 
     // @codingStandardsIgnoreStart


### PR DESCRIPTION
- test: avoid using class variables in this test to avoid mem leaks
- test: use https mock url by default

Totara test results:
```
...............................................................  63 / 324 ( 19%)
............................................................... 126 / 324 ( 38%)
............................................................... 189 / 324 ( 58%)
............................................................... 252 / 324 ( 77%)
.....................................S......................... 315 / 324 ( 97%)
.........                                                       324 / 324 (100%)

```

Resolves #823 