### PR TITLE
fix: loghandlers now optional and saving an existing flow should work

### DIFF
--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -57,7 +57,7 @@ class dataflow extends persistent {
             'enabled' => ['type' => PARAM_BOOL, 'default' => false],
             'concurrencyenabled' => ['type' => PARAM_BOOL, 'default' => false],
             'vars' => ['type' => PARAM_TEXT, 'default' => ''],
-            'loghandlers' => ['type' => PARAM_TEXT, 'default' => ''],
+            'loghandlers' => ['type' => PARAM_TEXT, 'default' => '', 'null' => NULL_ALLOWED],
             'timecreated' => ['type' => PARAM_INT, 'default' => 0],
             'userid' => ['type' => PARAM_INT, 'default' => 0],
             'timemodified' => ['type' => PARAM_INT, 'default' => 0],


### PR DESCRIPTION
Resolves #829


Before:

![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/0d7d6729-ae7c-4ec9-beb8-277e6e6a07cc)

After:

![image](https://github.com/catalyst/moodle-tool_dataflows/assets/9924643/2b7e2407-793d-425d-a109-7f8896ac1aaf)
