### PR TITLE
fix: set_variable step to only update when changed

### DIFF
--- a/classes/local/step/set_variable_trait.php
+++ b/classes/local/step/set_variable_trait.php
@@ -74,9 +74,15 @@ trait set_variable_trait {
      * @param mixed $value
      */
     public function run(var_root $varobject, string $field, $value) {
+        // Do nothing if the value has not changed.
+        $currentvalue = $varobject->get($field);
+        if ($currentvalue === $value) {
+            return;
+        }
+
         // Set the value in the variable tree.
         $varobject->set($field, $value);
-        $this->log("Set '{field}' as '{value}'", ['field' => $field, 'value' => $value]);
+        $this->log->info("Set '{field}' as '{value}'", ['field' => $field, 'value' => $value]);
 
         // We do not persist the value if it is a dry run.
         if ($this->is_dry_run()) {


### PR DESCRIPTION
- reduces noise (some flows might attempt to update the same value over and over)
- step being entered into will still display as expected.
