### PR TITLE
Unset class vars in test teardown

### DIFF
--- a/tests/tool_dataflows_connector_compression_test.php
+++ b/tests/tool_dataflows_connector_compression_test.php
@@ -45,6 +45,10 @@ class tool_dataflows_connector_compression_test extends \advanced_testcase {
         set_config('gzip_exec_path', '/usr/bin/gzip', 'tool_dataflows');
     }
 
+    protected function tearDown(): void {
+        $this->basedir = null;
+    }
+
     /**
      * Creates a test dataflow
      *

--- a/tests/tool_dataflows_flow_compression_test.php
+++ b/tests/tool_dataflows_flow_compression_test.php
@@ -58,6 +58,11 @@ class tool_dataflows_flow_compression_test extends \advanced_testcase {
         set_config('permitted_dirs', $basedir, 'tool_dataflows');
     }
 
+    protected function tearDown(): void {
+        $this->readdir = null;
+        $this->outdir = null;
+    }
+
     /**
      * Creates a test dataflow
      *


### PR DESCRIPTION
Before:
```
There were 3 failures:

1) tool_dataflows\tool_dataflows_connector_compression_test::test_gzip_compression_decompression
Property 'basedir' defined in 'tool_dataflows\tool_dataflows_connector_compression_test' was not reset after the test!
Please either find a way to avoid using a class variable or make sure it get's unset in the tearDown method to avoid creating memory leaks.

/var/www/site/server/lib/phpunit/classes/testcase.php:623
/var/www/sit/server/lib/phpunit/classes/testcase.php:148

2) tool_dataflows\tool_dataflows_connector_compression_test::test_gzip_validation
Property 'basedir' defined in 'tool_dataflows\tool_dataflows_connector_compression_test' was not reset after the test!
Please either find a way to avoid using a class variable or make sure it get's unset in the tearDown method to avoid creating memory leaks.

/var/www/site/server/lib/phpunit/classes/testcase.php:623
/var/www/site/server/lib/phpunit/classes/testcase.php:148

3) tool_dataflows\tool_dataflows_flow_compression_test::test_gzip_compression_decompression
Property 'readdir' defined in 'tool_dataflows\tool_dataflows_flow_compression_test' was not reset after the test!
Please either find a way to avoid using a class variable or make sure it get's unset in the tearDown method to avoid creating memory leaks.

/var/www/site/server/lib/phpunit/classes/testcase.php:623
/var/www/site/server/lib/phpunit/classes/testcase.php:148

```

After:
```
OK, but incomplete, skipped, or risky tests!
Tests: 328, Assertions: 744, Skipped: 1.
```