### PR TITLE
External API test fix #884

### DIFF
--- a/classes/external/trigger_dataflow.php
+++ b/classes/external/trigger_dataflow.php
@@ -16,6 +16,10 @@
 
 namespace tool_dataflows\external;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/externallib.php');
+
 use external_function_parameters;
 use external_single_structure;
 use external_value;


### PR DESCRIPTION
Closes #884 

From my testing, the ways to address this was either to use core_external\external_api (4.2+ only) or require externallib.

This is most likely only an issue when this class is called from the external api test, but requiring externallib.php shouldn't cause any harm and should work for both 4.1 and 4.2+.

I believe #796 has been resolved by https://github.com/catalyst/moodle-tool_dataflows/commit/87cf066716af3ced7ec022dbb0d827afd5adfa6d so we shouldn't need #803 

Side note - can we add this test to CI? 