### PR TITLE
make the eventlist compatible with Moodle 4.3

### DIFF
--- a/classes/local/step/trigger_event.php
+++ b/classes/local/step/trigger_event.php
@@ -133,11 +133,13 @@ class trigger_event extends trigger_step {
         $eventlist = \tool_monitor\eventlist::get_all_eventlist();
         $pluginlist = \tool_monitor\eventlist::get_plugin_list($eventlist);
         $plugineventlist = [];
-        foreach ($pluginlist as $plugin => $pluginname) {
-            foreach ($eventlist[$plugin] as $event => $eventname) {
-                // Filter out events which cannot be triggered for some reason.
-                if (!$event::is_deprecated()) {
-                    $plugineventlist[$event] = "{$pluginname}: {$eventname}";
+        foreach ($pluginlist as $plugintype => $plugins) {
+            foreach ($plugins as $plugin => $pluginname) {
+                foreach ($eventlist[$plugin] as $event => $eventname) {
+                    // Filter out events which cannot be triggered for some reason.
+                    if (!$event::is_deprecated()) {
+                        $plugineventlist[$event] = "{$pluginname}: {$eventname}";
+                    }
                 }
             }
         }

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024101000;
-$plugin->release = 2024101000;
+$plugin->version = 2024102100;
+$plugin->release = 2024102100;
 $plugin->requires = 2022112800;    // Our lowest supported Moodle (3.3.0).
-$plugin->supported = [400, 402];
+$plugin->supported = [400, 402, 403, 404, 405];
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.
 $plugin->component = 'tool_dataflows';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
The way the events list is composed has changed in 4.3 (or maybe in 4.2 but I have not tested).
This change makes the events list work again.