### PR TITLE
issue889 - Add maxlinelength as config for reader_csv

### DIFF
--- a/classes/local/step/reader_csv.php
+++ b/classes/local/step/reader_csv.php
@@ -33,6 +33,10 @@ class reader_csv extends reader_step {
     /** @var string */
     const DEFAULT_DELIMETER = ',';
 
+    /** @var int */
+    const DEFAULT_MAXLINELENGTH = 1000;
+
+
     /**
      * Return the definition of the fields available in this form.
      *
@@ -45,6 +49,7 @@ class reader_csv extends reader_step {
             'overwriteheaders' => ['type' => PARAM_BOOL],
             'continueonerror' => ['type' => PARAM_BOOL],
             'delimiter' => ['type' => PARAM_TEXT],
+            'maxlinelength' => ['type' => PARAM_INT],
         ];
     }
 
@@ -68,6 +73,7 @@ class reader_csv extends reader_step {
         $overwriteheaders = !empty($config->overwriteheaders);
         $continueonerror = !empty($config->continueonerror);
         $delimiter = $config->delimiter ?: self::DEFAULT_DELIMETER;
+        $maxlinelength = $config->maxlinelength ?: self::DEFAULT_MAXLINELENGTH;
         $path = $this->enginestep->engine->resolve_path($config->path);
 
         if (($handle = @fopen($path, 'r')) === false) {
@@ -190,5 +196,16 @@ class reader_csv extends reader_step {
             ['placeholder' => self::DEFAULT_DELIMETER],
             self::DEFAULT_DELIMETER
         );
+        // Max line length.
+        $mform->addElement(
+            'text',
+            'config_maxlinelength',
+            get_string('reader_csv:maxlinelength', 'tool_dataflows'),
+            ['placeholder' => self::DEFAULT_MAXLINELENGTH],
+            self::DEFAULT_MAXLINELENGTH
+        );
+        $mform->setType('config_maxlinelength', PARAM_INT);
+        $mform->addRule('config_maxlinelength', null, 'numeric', null, 'client');
+
     }
 }

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -384,6 +384,7 @@ $string['reader_csv:overwriteheaders_help'] = 'If checked, the headers supplied 
 $string['reader_csv:continueonerror'] = 'Continue on parsing errors';
 $string['reader_csv:continueonerror_help'] = 'If checked, the step will continue reading the next row of data if there are parsing errors on the current.';
 $string['reader_csv:header_field_count_mismatch'] = 'Row #{$a->rownumber}: Number of fields ({$a->numfields}) should match number of headers ({$a->numheaders})';
+$string['reader_csv:maxlinelength'] = 'Max Line Length';
 
 // Reader JSON.
 $string['reader_json:arrayexpression_help'] = 'Nested array to extract from JSON. For example, {$a->expression} will return the users array from the following JSON (If empty it is assumed the starting point of the JSON file is an array):{$a->jsonexample}';

--- a/tests/tool_dataflows_reader_csv_test.php
+++ b/tests/tool_dataflows_reader_csv_test.php
@@ -57,6 +57,7 @@ class tool_dataflows_reader_csv_test extends \advanced_testcase {
             'path' => $inputpath,
             'headers' => '',
             'delimiter' => ',',
+            'maxlinelength' => '1000',
         ]);
 
         // Create test input file.
@@ -97,6 +98,7 @@ class tool_dataflows_reader_csv_test extends \advanced_testcase {
             'path' => $inputpath,
             'headers' => implode(',', $headers),
             'delimiter' => ',',
+            'maxlinelength' => '1000',
         ]);
 
         // Create test input file.
@@ -138,6 +140,7 @@ class tool_dataflows_reader_csv_test extends \advanced_testcase {
             'path' => $path,
             'headers' => '',
             'delimiter' => ',',
+            'maxlinelength' => '1000',
         ]);
 
         $this->expectException('\moodle_exception');
@@ -167,6 +170,7 @@ class tool_dataflows_reader_csv_test extends \advanced_testcase {
             'headers' => implode(',', $headers),
             'overwriteheaders' => '1',
             'delimiter' => ',',
+            'maxlinelength' => '1000',
         ]);
 
         // Create test input file.
@@ -224,6 +228,7 @@ class tool_dataflows_reader_csv_test extends \advanced_testcase {
             'path' => $inputpath,
             'headers' => '',
             'delimiter' => ',',
+            'maxlinelength' => '1000',
         ]);
         $dataflow->add_step($reader);
         $steps[$reader->id] = $reader;


### PR DESCRIPTION
This PR adds maxlinelength as a config for reader_csv resolving #889 
Enabling the user to increase the maximum line characters that can be read.