### PR TITLE
Add config to publish to plugin directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,8 @@ on: [push, pull_request]
 jobs:
   ci:
     uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
-    #secrets:
-      # Required if you plan to publish (uncomment the below)
-      # moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
+    secrets:
+      moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
     with:
       codechecker_max_warnings: 0 # CI should now fail on phpcs / code checker warnings.
       disable_behat: true

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024053100;
-$plugin->release = 2024053100;
+$plugin->version = 2024053101;
+$plugin->release = 2024053101;
 $plugin->requires = 2022112800;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [400, 402];
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
**Description:** This PR adds a secret to the GitHub Actions workflow and bumps the plugin version to enable publishing to the Moodle Plugin Directory.

The plugin is passing all tests as seen in previous commits.  