### PR TITLE
Enhance logging details and verbosity

### DIFF
--- a/classes/admin/admin_setting_configcheckbox.php
+++ b/classes/admin/admin_setting_configcheckbox.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\admin;
 
-use tool_dataflows\admin\readonly_trait;
 
 /**
  * A custom class applying extra readonly checks to the base implementation.

--- a/classes/admin/admin_setting_configexecutable.php
+++ b/classes/admin/admin_setting_configexecutable.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\admin;
 
-use tool_dataflows\admin\readonly_trait;
 
 /**
  * A custom class applying extra readonly checks to the base implementation.

--- a/classes/admin/admin_setting_configmultiselect.php
+++ b/classes/admin/admin_setting_configmultiselect.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\admin;
 
-use tool_dataflows\admin\readonly_trait;
 
 /**
  * A custom class applying extra readonly checks to the base implementation.

--- a/classes/admin/admin_setting_configtext.php
+++ b/classes/admin/admin_setting_configtext.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\admin;
 
-use tool_dataflows\admin\readonly_trait;
 
 /**
  * A custom class applying extra readonly checks to the base implementation.

--- a/classes/admin/readonly_trait.php
+++ b/classes/admin/readonly_trait.php
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_dataflows\admin;
+
+use tool_dataflows\manager;
 
 /**
  * Read only trait
@@ -25,11 +28,6 @@
  * @copyright  Catalyst IT, 2023
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_dataflows\admin;
-
-use tool_dataflows\manager;
-
 trait readonly_trait {
 
     /**

--- a/classes/dataflow.php
+++ b/classes/dataflow.php
@@ -16,6 +16,7 @@
 
 namespace tool_dataflows;
 
+use Monolog\Logger;
 use core\persistent;
 use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\local\step\flow_step;
@@ -63,7 +64,8 @@ class dataflow extends persistent {
             'timemodified' => ['type' => PARAM_INT, 'default' => 0],
             'usermodified' => ['type' => PARAM_INT, 'default' => 0],
             'confighash' => ['type' => PARAM_TEXT, 'default' => ''],
-            'notifyonabort' => ['type' => PARAM_TEXT, 'default' => '']
+            'notifyonabort' => ['type' => PARAM_TEXT, 'default' => ''],
+            'minloglevel' => ['type' => PARAM_INT, 'default' => Logger::DEBUG],
         ];
     }
 

--- a/classes/dataflows_table.php
+++ b/classes/dataflows_table.php
@@ -140,7 +140,7 @@ class dataflows_table extends sql_table {
                 $content[] = $extrainfo;
             }
         }
-        $html .= implode('<br/>', $content);
+        $html .= implode('<br>', $content);
         return $html;
     }
 

--- a/classes/external/trigger_dataflow.php
+++ b/classes/external/trigger_dataflow.php
@@ -45,7 +45,7 @@ class trigger_dataflow extends \external_api {
         return new external_function_parameters([
             'dataflow' => new external_single_structure([
                 'id' => new external_value(PARAM_INT, 'dataflow record id'),
-            ])
+            ]),
         ]);
     }
 

--- a/classes/form/dataflow_form.php
+++ b/classes/form/dataflow_form.php
@@ -16,6 +16,7 @@
 
 namespace tool_dataflows\form;
 
+use Monolog\Logger;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use moodle_exception;
@@ -118,6 +119,18 @@ EOT;
 
         $mform->addElement('text', 'notifyonabort', get_string('notifyonabort', 'tool_dataflows'));
         $mform->addElement('static', 'notifyonabort_desc', '', get_string('notifyonabort_desc', 'tool_dataflows'));
+
+        $mform->addElement('select', 'minloglevel', get_string('minloglevel', 'tool_dataflows'), [
+            Logger::DEBUG     => 'DEBUG',
+            Logger::INFO      => 'INFO',
+            Logger::NOTICE    => 'NOTICE',
+            Logger::WARNING   => 'WARNING',
+            Logger::ERROR     => 'ERROR',
+            Logger::CRITICAL  => 'CRITICAL',
+            Logger::ALERT     => 'ALERT',
+            Logger::EMERGENCY => 'EMERGENCY',
+        ]);
+        $mform->addElement('static', 'minloglevel_desc', '', get_string('minloglevel_desc', 'tool_dataflows'));
 
         $this->add_action_buttons();
     }

--- a/classes/form/dataflow_form.php
+++ b/classes/form/dataflow_form.php
@@ -46,7 +46,7 @@ class dataflow_form extends \core\form\persistent {
             $mform->addElement(
                 'html',
                 \html_writer::div(
-                    get_string( 'readonly_active', 'tool_dataflows'),
+                    get_string('readonly_active', 'tool_dataflows'),
                     'alert alert-warning'
                 )
             );

--- a/classes/form/import_form.php
+++ b/classes/form/import_form.php
@@ -44,7 +44,7 @@ class import_form extends \moodleform {
             $mform->addElement(
                 'html',
                 \html_writer::div(
-                    get_string( 'readonly_active', 'tool_dataflows'),
+                    get_string('readonly_active', 'tool_dataflows'),
                     'alert alert-warning'
                 )
             );

--- a/classes/form/step_form.php
+++ b/classes/form/step_form.php
@@ -49,7 +49,7 @@ class step_form extends \core\form\persistent {
             $mform->addElement(
                 'html',
                 \html_writer::div(
-                    get_string( 'readonly_active', 'tool_dataflows'),
+                    get_string('readonly_active', 'tool_dataflows'),
                     'alert alert-warning'
                 )
             );

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -679,8 +679,8 @@ class engine {
         $this->get_variables()->set("states.$statusstring", microtime(true));
 
         $context = [
-                'isdryrun' => $this->isdryrun,
-                'status' => get_string('engine_status:'.self::STATUS_LABELS[$this->status], 'tool_dataflows'),
+            'isdryrun' => $this->isdryrun,
+            'status' => get_string('engine_status:'.self::STATUS_LABELS[$this->status], 'tool_dataflows'),
         ];
 
         $level = Logger::INFO;
@@ -865,7 +865,7 @@ class engine {
     /**
      * Send a notification email for abort if required.
      *
-     * @param \Throwable $reason A throwable representing the reason for abort.
+     * @param ?\Throwable $reason A throwable representing the reason for abort.
      */
     public function notify_on_abort(?\Throwable $reason) {
         // If configured to send email, attempt to notify of the abort reason.

--- a/classes/local/execution/engine.php
+++ b/classes/local/execution/engine.php
@@ -815,14 +815,17 @@ class engine {
             $loghandlers = $dataflowloghandlers;
         }
 
+        // Minimum logging levels - will display this level and above.
+        $minloglevel = $this->dataflow->get('minloglevel');
+
         // Default Moodle handler. Always on.
-        $mtracehandler = new mtrace_handler(Logger::DEBUG);
+        $mtracehandler = new mtrace_handler($minloglevel);
         $mtracehandler->setFormatter($lineformatter);
         $log->pushHandler($mtracehandler);
 
         // Log to the browser's dev console for a manual run.
         if (isset($loghandlers[log_handler::BROWSER_CONSOLE])) {
-            $log->pushHandler(new BrowserConsoleHandler(Logger::DEBUG));
+            $log->pushHandler(new BrowserConsoleHandler($minloglevel));
         }
 
         // Dataflow run logger.
@@ -834,7 +837,7 @@ class engine {
                 $this->dataflow->id . DIRECTORY_SEPARATOR .
                 $rundateformat . '_' . $this->run->name . '.log';
 
-            $streamhandler = new StreamHandler($dataflowrunlogpath, Logger::DEBUG);
+            $streamhandler = new StreamHandler($dataflowrunlogpath, $minloglevel);
             $streamhandler->setFormatter($lineformatter);
             $log->pushHandler($streamhandler);
         }
@@ -847,7 +850,7 @@ class engine {
                 'tool_dataflows' . DIRECTORY_SEPARATOR .
                 $this->dataflow->id . '.log';
 
-            $rotatingfilehandler = new RotatingFileHandler($dataflowlogpath, 0, Logger::DEBUG);
+            $rotatingfilehandler = new RotatingFileHandler($dataflowlogpath, 0, $minloglevel);
             $dateformat = 'Ymd';
             $filenameformat = '{date}_{filename}';
             $rotatingfilehandler->setFilenameFormat($filenameformat, $dateformat);

--- a/classes/local/execution/flow_engine_step.php
+++ b/classes/local/execution/flow_engine_step.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\local\execution;
 
-use tool_dataflows\parser;
 
 /**
  * Manages the execution of a flow step.

--- a/classes/local/execution/iterators/dataflow_iterator.php
+++ b/classes/local/execution/iterators/dataflow_iterator.php
@@ -18,7 +18,6 @@ namespace tool_dataflows\local\execution\iterators;
 
 use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\step\base_step;
-use tool_dataflows\local\step\flow_cap;
 
 /**
  * A mapping iterator that takes a PHP iterator as a source.

--- a/classes/local/execution/logging/mtrace_handler.php
+++ b/classes/local/execution/logging/mtrace_handler.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\local\execution\logging;
 
-use Monolog\Handler\AbstractHandler;
 use Monolog\Handler\AbstractProcessingHandler;
 
 /**
@@ -48,7 +47,6 @@ class mtrace_handler extends AbstractProcessingHandler {
      * Writes the record down to the log of the implementing handler
      *
      * @param  array $record
-     * @return void
      */
     protected function write(array $record): void {
         mtrace($record['formatted']);

--- a/classes/local/provider/expression_provider.php
+++ b/classes/local/provider/expression_provider.php
@@ -18,7 +18,6 @@ namespace tool_dataflows\local\provider;
 
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
-use tool_dataflows\parser;
 
 /**
  * Expression Provider

--- a/classes/local/service/step_service.php
+++ b/classes/local/service/step_service.php
@@ -18,7 +18,6 @@ namespace tool_dataflows\local\service;
 
 use tool_dataflows\local\execution\engine_flow_cap;
 use tool_dataflows\local\execution\engine_step;
-use tool_dataflows\local\step\reader_step;
 use tool_dataflows\step;
 
 /**

--- a/classes/local/step/abort_trait.php
+++ b/classes/local/step/abort_trait.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_dataflows\local\step;
+
 /**
  * Abort Step ..Trait
  *
@@ -27,9 +29,6 @@
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_dataflows\local\step;
-
 trait abort_trait {
 
     /**

--- a/classes/local/step/append_file_trait.php
+++ b/classes/local/step/append_file_trait.php
@@ -28,6 +28,7 @@ use tool_dataflows\helper;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait append_file_trait {
+
     /**
      * Returns whether or not the step configured, has a side effect.
      *

--- a/classes/local/step/base_step.php
+++ b/classes/local/step/base_step.php
@@ -22,7 +22,6 @@ use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\engine_step;
 use tool_dataflows\local\variables\var_root;
 use tool_dataflows\local\variables\var_step;
-use tool_dataflows\parser;
 use tool_dataflows\step;
 
 /**

--- a/classes/local/step/compression_trait.php
+++ b/classes/local/step/compression_trait.php
@@ -29,6 +29,7 @@ use tool_dataflows\helper;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait compression_trait {
+
     /**
      * Returns whether or not the step configured, has a side effect.
      *
@@ -188,10 +189,10 @@ trait compression_trait {
         return [
             'gzip' => (object) [
                 'name' => get_string('compression:method:gzip', 'tool_dataflows'),
-                'isexecutable' => function() {
+                'isexecutable' => function () {
                     return self::validate_executable(get_config('tool_dataflows', 'gzip_exec_path'));
-                }
-            ]
+                },
+            ],
         ];
     }
 
@@ -203,9 +204,7 @@ trait compression_trait {
      */
     private static function validate_executable(string $path) {
         if (!is_executable($path)) {
-            return get_string('compression:error:invalidexecutable', 'tool_dataflows', [
-                'path' => $path
-            ]);
+            return get_string('compression:error:invalidexecutable', 'tool_dataflows', ['path' => $path]);
         }
 
         return true;

--- a/classes/local/step/connector_copy_file.php
+++ b/classes/local/step/connector_copy_file.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\local\step;
 
-use tool_dataflows\helper;
 
 /**
  * Copy file connector step

--- a/classes/local/step/connector_debug_file_display.php
+++ b/classes/local/step/connector_debug_file_display.php
@@ -15,7 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_dataflows\local\step;
-use tool_dataflows\local\execution\engine_step;
 use tool_dataflows\helper;
 
 /**
@@ -93,5 +92,4 @@ class connector_debug_file_display extends connector_step {
             \html_writer::nonempty_tag('pre', get_string('path_help_examples', 'tool_dataflows')));
     }
 }
-
 

--- a/classes/local/step/connector_debugging.php
+++ b/classes/local/step/connector_debugging.php
@@ -15,7 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_dataflows\local\step;
-use tool_dataflows\local\execution\engine_step;
 
 /**
  * Debugging connector step type

--- a/classes/local/step/connector_sftp.php
+++ b/classes/local/step/connector_sftp.php
@@ -16,10 +16,7 @@
 
 namespace tool_dataflows\local\step;
 
-use phpseclib3\Crypt\Common\AsymmetricKey;
-use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Net\SFTP;
-use tool_dataflows\helper;
 
 /**
  * SFTP connector step type.

--- a/classes/local/step/copy_file_trait.php
+++ b/classes/local/step/copy_file_trait.php
@@ -27,6 +27,7 @@ use tool_dataflows\helper;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait copy_file_trait {
+
     /**
      * Return the definition of the fields available in this form.
      *

--- a/classes/local/step/curl_trait.php
+++ b/classes/local/step/curl_trait.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\local\step;
 
-use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\helper;
 
 defined('MOODLE_INTERNAL') || die();

--- a/classes/local/step/directory_file_list_trait.php
+++ b/classes/local/step/directory_file_list_trait.php
@@ -88,18 +88,18 @@ trait directory_file_list_trait {
         // Return value.
         $mform->addElement(
             'select', 'config_returnvalue', get_string('directory_file_list:returnvalue', 'tool_dataflows'), [
-            'basename' => get_string('directory_file_list:basename', 'tool_dataflows'),
-            'relativepath' => get_string('directory_file_list:relativepath', 'tool_dataflows'),
-            'absolutepath' => get_string('directory_file_list:absolutepath', 'tool_dataflows'),
+                'basename' => get_string('directory_file_list:basename', 'tool_dataflows'),
+                'relativepath' => get_string('directory_file_list:relativepath', 'tool_dataflows'),
+                'absolutepath' => get_string('directory_file_list:absolutepath', 'tool_dataflows'),
             ]
         );
 
         // Sort.
         $mform->addElement(
             'select', 'config_sort', get_string('directory_file_list:sort', 'tool_dataflows'), [
-            'alpha' => get_string('directory_file_list:alpha', 'tool_dataflows'),
-            'alpha_reverse' => get_string('directory_file_list:alpha_reverse', 'tool_dataflows'),
-            'natural' => get_string('directory_file_list:natural', 'tool_dataflows'),
+                'alpha' => get_string('directory_file_list:alpha', 'tool_dataflows'),
+                'alpha_reverse' => get_string('directory_file_list:alpha_reverse', 'tool_dataflows'),
+                'natural' => get_string('directory_file_list:natural', 'tool_dataflows'),
             ]
         );
 
@@ -176,15 +176,15 @@ trait directory_file_list_trait {
     /**
      * Apply various constraints/transforms to the list of files
      *
-     * @param  array         $filelist
-     * @param  string        $returnvalue
-     * @param  string        $sort
-     * @param  int           $offset
-     * @param  int           $limit
-     * @param  bool          $includedir
-     * @param  string        $basepath
-     * @param  string        $pattern
-     * @return array new file list
+     * @param  array        $filelist
+     * @param  string       $returnvalue
+     * @param  string       $sort
+     * @param  int          $offset
+     * @param  int|null     $limit
+     * @param  bool         $includedir
+     * @param  string       $basepath
+     * @param  string|null  $pattern
+     * @return array  new file list
      */
     public function apply_list_constraints(
         array $filelist,
@@ -194,7 +194,7 @@ trait directory_file_list_trait {
         ?int $limit,
         bool $includedir,
         string $basepath,
-        string $pattern = null
+        ?string $pattern = null
     ): array {
         // Apply filter for excluding directories/folders.
         // This is not related to recursive lookups in any way.

--- a/classes/local/step/file_put_content_trait.php
+++ b/classes/local/step/file_put_content_trait.php
@@ -27,6 +27,7 @@ use tool_dataflows\helper;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait file_put_content_trait {
+
     /**
      * Return the definition of the fields available in this form.
      *
@@ -100,7 +101,6 @@ trait file_put_content_trait {
 
         return $errors ?: true;
     }
-
 
     /**
      * Executes the step

--- a/classes/local/step/flow_copy_file.php
+++ b/classes/local/step/flow_copy_file.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\local\step;
 
-use tool_dataflows\helper;
 
 /**
  * Copy file flow step

--- a/classes/local/step/flow_sftp.php
+++ b/classes/local/step/flow_sftp.php
@@ -16,10 +16,7 @@
 
 namespace tool_dataflows\local\step;
 
-use phpseclib3\Crypt\Common\AsymmetricKey;
-use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Net\SFTP;
-use tool_dataflows\helper;
 
 /**
  * SFTP connector step type.

--- a/classes/local/step/flow_web_service.php
+++ b/classes/local/step/flow_web_service.php
@@ -24,9 +24,7 @@ use core_user;
 use core\session\manager;
 use external_api;
 use moodle_exception;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
-use Throwable;
 use tool_dataflows\parser;
 
 /**
@@ -325,7 +323,7 @@ EOF;
 
             $response['error'] = false;
             $response['data'] = $result;
-        } catch (Throwable $e) {
+        } catch (\Throwable $e) {
             $exception = get_exception_info($e);
             unset($exception->a);
             $exception->backtrace = format_backtrace($exception->backtrace, true);

--- a/classes/local/step/gpg_trait.php
+++ b/classes/local/step/gpg_trait.php
@@ -27,6 +27,7 @@ use tool_dataflows\helper;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait gpg_trait {
+
     /**
      * Returns whether or not the step configured, has a side effect.
      *

--- a/classes/local/step/hash_file_trait.php
+++ b/classes/local/step/hash_file_trait.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_dataflows\local\step;
+
+use tool_dataflows\helper;
+
 /**
  * Hash file flow step
  *
@@ -22,11 +26,6 @@
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_dataflows\local\step;
-
-use tool_dataflows\helper;
-
 trait hash_file_trait {
 
     /**

--- a/classes/local/step/log_trait.php
+++ b/classes/local/step/log_trait.php
@@ -98,7 +98,7 @@ trait log_trait {
 
         // Call the log method with the relevant levels, if a message is supplied.
         if ($message !== '') {
-            $this->log->log($config->level, $message);
+            $this->log->log($config->level, $message, (array) $input);
         }
 
         return $input;

--- a/classes/local/step/log_trait.php
+++ b/classes/local/step/log_trait.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_dataflows\local\step;
+
+use Symfony\Bridge\Monolog\Logger;
+
 /**
  * Log trait
  *
@@ -22,17 +26,12 @@
  * @copyright  Catalyst IT, 2023
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_dataflows\local\step;
-
-use Symfony\Bridge\Monolog\Logger;
-
 trait log_trait {
 
     /**
      * Logging levels from syslog protocol defined in RFC 5424
      *
-     * @var array $levels Logging levels
+     * @var array Logging levels
      */
     protected static $levels = [
         Logger::DEBUG     => 'DEBUG',

--- a/classes/local/step/remove_file_trait.php
+++ b/classes/local/step/remove_file_trait.php
@@ -27,6 +27,7 @@ use tool_dataflows\helper;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait remove_file_trait {
+
     /**
      * Returns whether or not the step configured, has a side effect.
      *

--- a/classes/local/step/s3_trait.php
+++ b/classes/local/step/s3_trait.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_dataflows\local\step;
+
+use tool_dataflows\helper;
+
 /**
  * S3 copy step ..trait
  *
@@ -23,11 +27,6 @@
  * @copyright  Catalyst IT, 2022
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_dataflows\local\step;
-
-use tool_dataflows\helper;
-
 trait s3_trait {
 
     /**

--- a/classes/local/step/set_multiple_variables_trait.php
+++ b/classes/local/step/set_multiple_variables_trait.php
@@ -17,7 +17,6 @@
 namespace tool_dataflows\local\step;
 
 use tool_dataflows\local\variables\var_root;
-use tool_dataflows\local\variables\var_object_visible;
 
 /**
  * Set multiple variables trait

--- a/classes/local/step/set_variable_trait.php
+++ b/classes/local/step/set_variable_trait.php
@@ -35,6 +35,7 @@ use tool_dataflows\local\variables\var_object_visible;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 trait set_variable_trait {
+
     /**
      * Returns whether or not the step configured, has a side effect
      *

--- a/classes/local/step/sftp_trait.php
+++ b/classes/local/step/sftp_trait.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows\local\step;
 
-use MoodleQuickForm;
 use phpseclib3\Crypt\Common\AsymmetricKey;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Net\SFTP;
@@ -34,13 +33,13 @@ use tool_dataflows\helper;
  */
 trait sftp_trait {
 
-    /** Shorthand sftp scheme for use in config. */
+    /** @var string Shorthand sftp scheme for use in config. */
     protected static $sftpprefix = 'sftp';
 
-    /** Default port to connect to. */
+    /** @var int Default port to connect to. */
     protected static $defaultport = 22;
 
-    /** Array of SFTP objects to use for performance reasons. */
+    /** @var array SFTP objects to use for performance reasons. */
     protected $sftp = [];
 
     /**

--- a/classes/local/step/sql_trait.php
+++ b/classes/local/step/sql_trait.php
@@ -57,7 +57,7 @@ trait sql_trait {
         $sql = preg_replace($pattern, '?', $sql);
 
         // Now we can map all the variables to their real values.
-        $vars = array_map(function($el) use ($variables, $parser) {
+        $vars = array_map(function ($el) use ($variables, $parser) {
             $hasexpression = true;
             $max = 5;
             while ($hasexpression && $max) {
@@ -88,7 +88,7 @@ trait sql_trait {
      * Returns a clarified error message if applicable.
      *
      * @param   string $message
-     * @param   string $sql replacement for the expression held by default.
+     * @param   string|null $sql replacement for the expression held by default.
      * @return  string clarified message if applicable
      */
     private function clarify_parser_error(string $message, ?string $sql = null): string {
@@ -256,7 +256,7 @@ trait sql_trait {
         $token = $matches[0] ?? '';
         $emptydefault = new \stdClass();
 
-        switch(strtoupper($token)) {
+        switch (strtoupper($token)) {
             case 'SELECT':
                 // Execute the query using get_records instead of get_record.
                 // This is so we can expose the number of records returned which

--- a/classes/local/step/trigger_step.php
+++ b/classes/local/step/trigger_step.php
@@ -16,11 +16,6 @@
 
 namespace tool_dataflows\local\step;
 
-use tool_dataflows\local\execution\engine;
-use tool_dataflows\local\execution\iterators\iterator;
-use tool_dataflows\local\execution\iterators\dataflow_iterator;
-use tool_dataflows\local\execution\flow_engine_step;
-use tool_dataflows\local\execution\engine_step;
 
 /**
  * Base class for trigger step types.

--- a/classes/local/variables/var_dataflow.php
+++ b/classes/local/variables/var_dataflow.php
@@ -16,9 +16,7 @@
 
 namespace tool_dataflows\local\variables;
 
-use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\dataflow;
-use tool_dataflows\helper;
 use tool_dataflows\local\execution\engine;
 
 /**

--- a/classes/parser.php
+++ b/classes/parser.php
@@ -20,7 +20,6 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\Lexer;
-use Symfony\Component\ExpressionLanguage\Node;
 use Symfony\Component\ExpressionLanguage\Token;
 use Symfony\Component\ExpressionLanguage\TokenStream;
 use Symfony\Component\Yaml\Exception\ParseException;
@@ -242,9 +241,9 @@ class parser {
     /**
      * Evalulates the expression provided and on fail will throw an exception.
      *
-     * @param   string $expression
-     * @param   array $variables containing anything relevant to the evaluation of the result
-     * @param   callable $failcallback containing anything relevant to the evaluation of the result
+     * @param   string         $expression
+     * @param   array          $variables containing anything relevant to the evaluation of the result
+     * @param   callable|null  $failcallback containing anything relevant to the evaluation of the result
      * @return  mixed
      */
     public function evaluate_or_fail(string $expression, array $variables, ?callable $failcallback = null) {
@@ -267,7 +266,7 @@ class parser {
      *
      * @param   string $string
      * @param   array $variables containing anything relevant to the evaluation of the result
-     * @param   callable $failcallback containing anything relevant to the evaluation of the result
+     * @param   callable|null $failcallback containing anything relevant to the evaluation of the result
      * @return  mixed
      */
     private function internal_evaluator(string $string, array $variables, ?callable $failcallback) {

--- a/classes/run.php
+++ b/classes/run.php
@@ -119,7 +119,7 @@ class run extends persistent {
      * Sets the snapshot of the current state of the run
      *
      * @param  string $status the engine's status
-     * @param  string $currentstate the yaml string representation of the state of the dataflow
+     * @param  string|null $currentstate the yaml string representation of the state of the dataflow
      */
     public function snapshot(string $status, ?string $currentstate = null) {
         $this->status = $status;

--- a/classes/task/process_dataflow_ad_hoc.php
+++ b/classes/task/process_dataflow_ad_hoc.php
@@ -41,9 +41,8 @@ class process_dataflow_ad_hoc extends \core\task\adhoc_task {
      * and schedules for it to be run.
      *
      * @param dataflow $dataflow
-     * @return void
      */
-    public static function queue_adhoctask(dataflow $dataflow): void {
+    public static function queue_adhoctask(dataflow $dataflow) {
         $task = new process_dataflow_ad_hoc();
 
         // No extra data can go in here, otherwise the de-duplication will not work.

--- a/classes/task/process_dataflows.php
+++ b/classes/task/process_dataflows.php
@@ -20,7 +20,6 @@ use tool_dataflows\dataflow;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\scheduler;
 use tool_dataflows\local\event_processor;
-use tool_dataflows\task\process_dataflow_ad_hoc;
 
 /**
  * Process queued dataflows.

--- a/classes/visualiser.php
+++ b/classes/visualiser.php
@@ -66,7 +66,7 @@ class visualiser {
      * generated image content.
      *
      * @param  string $dotscript the script for DOT to generate the image.
-     * @param  string $type supported image types: jpg, gif, png, svg, ps.
+     * @param  string|null $type supported image types: jpg, gif, png, svg, ps.
      * @return binary|string content of the generated image on success, empty string on failure.
      *
      * @author     cjiang

--- a/dataflow-action.php
+++ b/dataflow-action.php
@@ -81,7 +81,6 @@ switch ($action) {
         break;
 }
 
-
 // Redirect to the dataflows details page.
 if ($notifystring !== null) {
     redirect($returnurl, get_string($action.'_dataflow_successful', 'tool_dataflows', $dataflow->name),

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/dataflows/db" VERSION="20230720" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
+<XMLDB PATH="admin/tool/dataflows/db" VERSION="20241010" COMMENT="XMLDB file for Moodle admin/tool/dataflows"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -19,6 +19,7 @@
         <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Who last modified this record?"/>
         <FIELD NAME="confighash" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false" COMMENT="The config hash of the most recent run"/>
         <FIELD NAME="notifyonabort" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Email address to notify aborted runs to."/>
+        <FIELD NAME="minloglevel" TYPE="int" LENGTH="2" NOTNULL="false" DEFAULT="100" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/services.php
+++ b/db/services.php
@@ -55,5 +55,5 @@ $services = [
         'functions' => ['tool_dataflows_trigger_dataflow'],
         'restrictedusers' => 0,
         'shortname' => 'dataflow_service',
-    ]
+    ],
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -333,7 +333,7 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         $type = \tool_dataflows\local\step\trigger_cron::class;
         $newfields = [
             'retryinterval' => 0,
-            'retrycount' => 0
+            'retrycount' => 0,
         ];
         xmldb_tool_dataflows_step_config_helper($type, $newfields);
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -341,6 +341,21 @@ function xmldb_tool_dataflows_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2024030201, 'tool', 'dataflows');
     }
 
+    if ($oldversion < 2024101000) {
+
+        // Define field minloglevel to be added to tool_dataflows.
+        $table = new xmldb_table('tool_dataflows');
+        $field = new xmldb_field('minloglevel', XMLDB_TYPE_INTEGER, '2', null, null, null, '100', 'notifyonabort');
+
+        // Conditionally launch add field minloglevel.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Dataflows savepoint reached.
+        upgrade_plugin_savepoint(true, 2024101000, 'tool', 'dataflows');
+    }
+
     return true;
 }
 
@@ -390,4 +405,3 @@ function xmldb_tool_dataflows_step_config_helper(string $type, array $newfields)
     }
     $transaction->allow_commit();
 }
-

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -110,7 +110,7 @@ Reason: {$a->reason}
 See the run logs for further details.';
 $string['notifyonabort_subject'] = 'Dataflow run aborted: {$a}';
 $string['minloglevel'] = 'Minimum Log level';
-$string['minloglevel_desc'] = 'This defines the minimum level to log. For example, if set at WARNING, it will only log WARNING messages and above, like ERROR, CRITICAL, ALERT, and EMERGENCY';
+$string['minloglevel_desc'] = 'This defines the minimum level to log. For example, if set at WARNING, it will only log WARNING messages and above, like ERROR, CRITICAL, ALERT, and EMERGENCY.';
 
 // Dataflow import form.
 $string['dataflow_file'] = 'Dataflow file';

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -109,6 +109,8 @@ Reason: {$a->reason}
 
 See the run logs for further details.';
 $string['notifyonabort_subject'] = 'Dataflow run aborted: {$a}';
+$string['minloglevel'] = 'Minimum Log level';
+$string['minloglevel_desc'] = 'This defines the minimum level to log. For example, if set at WARNING, it will only log WARNING messages and above, like ERROR, CRITICAL, ALERT, and EMERGENCY';
 
 // Dataflow import form.
 $string['dataflow_file'] = 'Dataflow file';

--- a/runs.php
+++ b/runs.php
@@ -97,7 +97,6 @@ $PAGE->set_pagelayout('admin');
 $PAGE->set_heading($dataflow->name . ': ' . $pageheading);
 echo $output->header();
 
-
 // No hide/show links under each column.
 $table->attributes['class'] = 'table-sm w-auto';
 $table->build();

--- a/settings.php
+++ b/settings.php
@@ -52,7 +52,7 @@ if ($hassiteconfig) {
                 'tool_dataflows/readonly_active',
                 '',
                 html_writer::div(
-                    get_string( 'readonly_active', 'tool_dataflows'),
+                    get_string('readonly_active', 'tool_dataflows'),
                     'alert alert-warning'
                 )
             ));

--- a/step.php
+++ b/step.php
@@ -71,7 +71,6 @@ try {
     redirect($overviewurl);
 }
 
-
 // Set the PAGE URL (and mandatory context). Note the ID being recorded, this is important.
 $PAGE->set_context($context);
 $PAGE->set_url($url);

--- a/templates/step-summary.mustache
+++ b/templates/step-summary.mustache
@@ -63,20 +63,20 @@
         <div class="col-sm">
             <h6 class="text-center">{{#str}} inputs, tool_dataflows {{/str}}</h6>
             {{#inputlist}}
-                <a href="{{{href}}}">{{label}}</a><br/>
+                <a href="{{{href}}}">{{label}}</a><br>
             {{/inputlist}}
             {{^inputlist}}
                 <p>{{#str}} no_inputs, tool_dataflows {{/str}}</p>
             {{/inputlist}}
         </div>
         <div class="col-sm text-center border-right border-left">
-            {{{dotimage}}}<br/>
-            {{typename}}<br/>
+            {{{dotimage}}}<br>
+            {{typename}}<br>
         </div>
         <div class="col-sm">
             <h6 class="text-center">{{#str}} outputs, tool_dataflows {{/str}}</h6>
             {{#outputlist}}
-                <a href="{{{href}}}">{{label}}</a><br/>
+                <a href="{{{href}}}">{{label}}</a><br>
             {{/outputlist}}
             {{^outputlist}}
                 <p>{{#str}} no_outputs, tool_dataflows {{/str}}</p>
@@ -84,7 +84,7 @@
         </div>
     </div>
     <div class="card-body">
-        {{inputrequirements}}<br/>
+        {{inputrequirements}}<br>
         {{outputrequirements}}
     </div>
 </div>

--- a/tests/application_trait.php
+++ b/tests/application_trait.php
@@ -14,15 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Helper unit test methods that are highly related to the application.
- *
- * @package    tool_dataflows
- * @author     Kevin Pham <kevinpham@catalyst-au.net>
- * @copyright  Catalyst IT, 2022
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace tool_dataflows;
 
 /**

--- a/tests/local/execution/array_in_type.php
+++ b/tests/local/execution/array_in_type.php
@@ -18,7 +18,6 @@ namespace tool_dataflows\local\execution;
 
 use tool_dataflows\local\execution\iterators\iterator;
 use tool_dataflows\local\execution\iterators\dataflow_iterator;
-use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\step\reader_step;
 
 /**

--- a/tests/local/execution/array_out_type.php
+++ b/tests/local/execution/array_out_type.php
@@ -18,7 +18,6 @@ namespace tool_dataflows\local\execution;
 
 use tool_dataflows\local\execution\iterators\iterator;
 use tool_dataflows\local\execution\iterators\dataflow_iterator;
-use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\step\writer_step;
 
 /**

--- a/tests/local/execution/direct_in_type.php
+++ b/tests/local/execution/direct_in_type.php
@@ -16,10 +16,8 @@
 
 namespace tool_dataflows\local\execution;
 
-use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\local\execution\iterators\iterator;
 use tool_dataflows\local\execution\iterators\dataflow_iterator;
-use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\step\reader_step;
 
 /**

--- a/tests/local/execution/flow_callback_step.php
+++ b/tests/local/execution/flow_callback_step.php
@@ -16,9 +16,6 @@
 
 namespace tool_dataflows\local\execution;
 
-use tool_dataflows\local\execution\iterators\iterator;
-use tool_dataflows\local\execution\iterators\dataflow_iterator;
-use tool_dataflows\local\execution\flow_engine_step;
 use tool_dataflows\local\step\flow_step;
 
 /**

--- a/tests/local/execution/test_engine.php
+++ b/tests/local/execution/test_engine.php
@@ -16,8 +16,6 @@
 
 namespace tool_dataflows\local\execution;
 
-use tool_dataflows\dataflow;
-use tool_dataflows\step;
 
 /**
  * A engine subclass used for testing

--- a/tests/local/execution/tool_dataflows_basic_execution_test.php
+++ b/tests/local/execution/tool_dataflows_basic_execution_test.php
@@ -17,7 +17,6 @@
 namespace tool_dataflows\local\execution;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\local\execution\engine;
 use tool_dataflows\dataflow;
 use tool_dataflows\step;
 use tool_dataflows\test_dataflows;

--- a/tests/local/execution/tool_dataflows_engine_test.php
+++ b/tests/local/execution/tool_dataflows_engine_test.php
@@ -144,7 +144,7 @@ class tool_dataflows_engine_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function dataflow_provider(): array {
+    public static function dataflow_provider(): array {
         $dataflow = new dataflow();
         $dataflow->name = 'two-step';
         $dataflow->enabled = true;
@@ -241,7 +241,7 @@ class tool_dataflows_engine_test extends \advanced_testcase {
                     'tool_dataflows',
                     [
                         'to' => engine::STATUS_LABELS[engine::STATUS_INITIALISED],
-                        'from' => engine::STATUS_LABELS[engine::STATUS_FINALISED]
+                        'from' => engine::STATUS_LABELS[engine::STATUS_FINALISED],
                     ]
                 ));
             $engine->set_status(engine::STATUS_INITIALISED);

--- a/tests/tool_dataflows_ad_hoc_task_test.php
+++ b/tests/tool_dataflows_ad_hoc_task_test.php
@@ -67,7 +67,7 @@ class tool_dataflows_ad_hoc_task_test extends \advanced_testcase {
      */
     public function test_cron_adhoc_task_creation() {
         // Create three CRON triggered dataflows.
-        array_map(function($i) {
+        array_map(function ($i) {
             return $this->create_dataflow();
         }, range(0, 2));
 

--- a/tests/tool_dataflows_append_file_step_test.php
+++ b/tests/tool_dataflows_append_file_step_test.php
@@ -54,7 +54,7 @@ class tool_dataflows_append_file_step_test extends \advanced_testcase {
     /** File list name. */
     const FILE_LIST_NAME = 'files.csv';
 
-    /** @var string  Base directory. */
+    /** @var string Base directory. */
     private $basedir;
 
     /**
@@ -111,7 +111,7 @@ class tool_dataflows_append_file_step_test extends \advanced_testcase {
             Yaml::dump([
                 'dir1' => 'everywhere',
                 'dir2' => '/anywhere',
-                'dir3' => 'sftp://somewhere'
+                'dir3' => 'sftp://somewhere',
             ]),
             'tool_dataflows'
         );
@@ -126,7 +126,7 @@ class tool_dataflows_append_file_step_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function has_sideeffect_provider(): array {
+    public static function has_sideeffect_provider(): array {
         return [
             ['test.txt', false],
             ['/test.txt', true],

--- a/tests/tool_dataflows_concurrency_test.php
+++ b/tests/tool_dataflows_concurrency_test.php
@@ -17,8 +17,6 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\step;
-use tool_dataflows\dataflow;
 
 /**
  * tests some of the code around concurrency.

--- a/tests/tool_dataflows_connector_compression_test.php
+++ b/tests/tool_dataflows_connector_compression_test.php
@@ -30,7 +30,7 @@ use tool_dataflows\local\step\connector_compression;
  * @covers    \tool_dataflows\local\step\connector_compression
  */
 class tool_dataflows_connector_compression_test extends \advanced_testcase {
-    /** @var string $basedir base test directory for files **/
+    /** @var string base test directory for files * */
     private $basedir;
 
     /**
@@ -67,7 +67,7 @@ class tool_dataflows_connector_compression_test extends \advanced_testcase {
             'from' => $from,
             'to' => $tocompressed,
             'method' => $method,
-            'command' => 'compress'
+            'command' => 'compress',
         ]);
 
         $compress->name = 'compress';
@@ -80,7 +80,7 @@ class tool_dataflows_connector_compression_test extends \advanced_testcase {
             'from' => $tocompressed,
             'to' => $todecompressed,
             'method' => $method,
-            'command' => 'decompress'
+            'command' => 'decompress',
         ]);
 
         $decompress->depends_on([$compress]);

--- a/tests/tool_dataflows_connector_curl_test.php
+++ b/tests/tool_dataflows_connector_curl_test.php
@@ -20,8 +20,6 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\local\step\connector_curl;
 use tool_dataflows\local\execution\engine;
-use tool_dataflows\step;
-use tool_dataflows\dataflow;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -324,7 +322,7 @@ class tool_dataflows_connector_curl_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function has_side_effect_provider(): array {
+    public static function has_side_effect_provider(): array {
         return [
             ['my/in.txt', 'get', false, false],
             ['my/in.txt', 'head', false, false],

--- a/tests/tool_dataflows_connector_debug_file_display_test.php
+++ b/tests/tool_dataflows_connector_debug_file_display_test.php
@@ -20,7 +20,6 @@ use Symfony\Component\Yaml\Yaml;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\execution\direct_in_type;
 use tool_dataflows\local\step\connector_debug_file_display;
-use tool_dataflows\local\step\writer_stream;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/tool_dataflows_connector_directory_file_count_test.php
+++ b/tests/tool_dataflows_connector_directory_file_count_test.php
@@ -87,7 +87,7 @@ class tool_dataflows_connector_directory_file_count_test extends \advanced_testc
      *
      * @return  array of expected counts
      */
-    public function count_provider(): array {
+    public static function count_provider(): array {
         return [
             [0],
             [10],

--- a/tests/tool_dataflows_connector_s3_test.php
+++ b/tests/tool_dataflows_connector_s3_test.php
@@ -56,7 +56,7 @@ class tool_dataflows_connector_s3_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function path_in_s3_data_provider(): array {
+    public static function path_in_s3_data_provider(): array {
         return [
             ['s3://path/to/file', true],
             ['s3://path/to/', true],
@@ -131,7 +131,7 @@ class tool_dataflows_connector_s3_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function path_input_and_expected_data_provider(): array {
+    public static function path_input_and_expected_data_provider(): array {
         return [
             ['s3://path/to/file', 'path/to/file'],
             ['s3://path/to/', 'path/to/'],
@@ -181,7 +181,7 @@ class tool_dataflows_connector_s3_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function validate_for_run_provider(): array {
+    public static function validate_for_run_provider(): array {
         $s3file = 's3://test/source.csv';
         $relativefile = 'test/source.csv';
         $absolutefile = '/var/source.csv';
@@ -290,14 +290,14 @@ class tool_dataflows_connector_s3_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function has_side_effect_provider(): array {
+    public static function has_side_effect_provider(): array {
         return [
-            [ 's3://test/source.csv', 's3://test/target.csv', true],
-            [ 's3://test/source.csv', 'test/target.csv', false],
-            [ 'test/source.csv', 's3://test/target.csv', true],
-            [ 's3://test/source.csv', '${{global.vars.abs}}', true],
-            [ 's3://test/source.csv', '${{global.vars.rel}}', false],
-            [ 'test/source.csv', 's3://${{global.vars.rel}}', true],
+            ['s3://test/source.csv', 's3://test/target.csv', true],
+            ['s3://test/source.csv', 'test/target.csv', false],
+            ['test/source.csv', 's3://test/target.csv', true],
+            ['s3://test/source.csv', '${{global.vars.abs}}', true],
+            ['s3://test/source.csv', '${{global.vars.rel}}', false],
+            ['test/source.csv', 's3://${{global.vars.rel}}', true],
         ];
     }
 }

--- a/tests/tool_dataflows_dot_escape_test.php
+++ b/tests/tool_dataflows_dot_escape_test.php
@@ -17,8 +17,6 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\local\execution\engine;
-use tool_dataflows\local\step\reader_json;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -48,7 +46,7 @@ class tool_dataflows_dot_escape_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function escape_dot_dataprovider() {
+    public static function escape_dot_dataprovider(): array {
 
         $sqlinput = <<<'INPUT'
 '  "  \ / \\ SQL

--- a/tests/tool_dataflows_flow_compression_test.php
+++ b/tests/tool_dataflows_flow_compression_test.php
@@ -31,10 +31,10 @@ use tool_dataflows\local\step\reader_directory_file_list;
  * @covers    \tool_dataflows\local\step\connector_compression
  */
 class tool_dataflows_flow_compression_test extends \advanced_testcase {
-    /** @var string $readdir directory with files in it to read from for flow step */
+    /** @var string directory with files in it to read from for flow step */
     private $readdir;
 
-    /** @var string $outdir directory where the compressed/decompressed files are outputted to */
+    /** @var string directory where the compressed/decompressed files are outputted to */
     private $outdir;
 
     /**
@@ -80,7 +80,7 @@ class tool_dataflows_flow_compression_test extends \advanced_testcase {
             'returnvalue' => 'basename',
             'sort' => 'alpha',
             'offset' => '0',
-            'limit' => '0'
+            'limit' => '0',
         ]);
         $reader->name = 'reader';
         $reader->type = reader_directory_file_list::class;
@@ -91,7 +91,7 @@ class tool_dataflows_flow_compression_test extends \advanced_testcase {
             'from' => $this->readdir . '/${{record.filename}}',
             'to' => $this->outdir . '/${{record.filename}}-out.gz',
             'method' => $method,
-            'command' => 'compress'
+            'command' => 'compress',
         ]);
         $compress->depends_on([$reader]);
         $compress->name = 'compress';
@@ -103,7 +103,7 @@ class tool_dataflows_flow_compression_test extends \advanced_testcase {
             'from' => $this->outdir . '/${{record.filename}}-out.gz',
             'to' => $this->outdir . '/${{record.filename}}-out-decompressed.txt',
             'method' => $method,
-            'command' => 'decompress'
+            'command' => 'decompress',
         ]);
         $decompress->depends_on([$compress]);
         $decompress->name = 'decompress';
@@ -136,16 +136,16 @@ class tool_dataflows_flow_compression_test extends \advanced_testcase {
         // Check the files were outputted correctly.
         // Note we check the mime type rather than the file extension
         // since the extension may be misleading.
-        $outdircontenttypes = array_map(function($filename) {
+        $outdircontenttypes = array_map(function ($filename) {
             $fullpath = $this->outdir . '/' . $filename;
             return mime_content_type($fullpath);
         }, scandir($this->outdir));
 
-        $this->assertCount(2, array_filter($outdircontenttypes, function($type) {
+        $this->assertCount(2, array_filter($outdircontenttypes, function ($type) {
             return $type == 'application/gzip' || $type == 'application/x-gzip';
         }));
 
-        $this->assertCount(2, array_filter($outdircontenttypes, function($type) {
+        $this->assertCount(2, array_filter($outdircontenttypes, function ($type) {
             return $type == 'text/plain';
         }));
     }

--- a/tests/tool_dataflows_flow_hash_file_test.php
+++ b/tests/tool_dataflows_flow_hash_file_test.php
@@ -70,7 +70,7 @@ class tool_dataflows_flow_hash_file_test extends \advanced_testcase {
      *
      * @return  array
      */
-    public function hash_file_provider() {
+    public static function hash_file_provider(): array {
         $combinations = [];
         $content = 'Hello World';
 

--- a/tests/tool_dataflows_flow_set_variable_test.php
+++ b/tests/tool_dataflows_flow_set_variable_test.php
@@ -22,7 +22,6 @@ use tool_dataflows\local\execution\array_out_type;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\step\flow_abort;
 use tool_dataflows\local\step\flow_set_variable;
-use tool_dataflows\test_dataflows;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/tool_dataflows_flow_sql_test.php
+++ b/tests/tool_dataflows_flow_sql_test.php
@@ -17,9 +17,7 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\dataflow;
 use tool_dataflows\local\execution\engine;
-use tool_dataflows\step;
 use tool_dataflows\local\step\flow_sql;
 
 defined('MOODLE_INTERNAL') || die();
@@ -155,9 +153,7 @@ class tool_dataflows_flow_sql_test extends \advanced_testcase {
         ]);
         $this->dataflow->save();
 
-        $this->flow->config = Yaml::dump([
-            'sql' => 'SELECT * FROM {course} WHERE id = ${{dataflow.vars.courseid}}',
-        ]);
+        $this->flow->config = Yaml::dump(['sql' => 'SELECT * FROM {course} WHERE id = ${{dataflow.vars.courseid}}']);
         $this->flow->save();
 
         ob_start();
@@ -186,9 +182,7 @@ class tool_dataflows_flow_sql_test extends \advanced_testcase {
 
         // Execute a query where the sql is not well formed.
         // This should return null and a count of 0.
-        $this->flow->config = Yaml::dump([
-            'sql' => 'SELECT *',
-        ]);
+        $this->flow->config = Yaml::dump(['sql' => 'SELECT *']);
         $this->flow->save();
 
         ob_start();
@@ -213,9 +207,7 @@ class tool_dataflows_flow_sql_test extends \advanced_testcase {
 
         // Execute a query where no records are returned.
         // This should return null and a count of 0.
-        $this->flow->config = Yaml::dump([
-            'sql' => 'SELECT * FROM {course} WHERE id = -1',
-        ]);
+        $this->flow->config = Yaml::dump(['sql' => 'SELECT * FROM {course} WHERE id = -1']);
         $this->flow->save();
 
         ob_start();

--- a/tests/tool_dataflows_flow_transformer_alter_test.php
+++ b/tests/tool_dataflows_flow_transformer_alter_test.php
@@ -29,15 +29,14 @@ use tool_dataflows\local\execution\engine;
  */
 class tool_dataflows_flow_transformer_alter_test extends \advanced_testcase {
 
-
     /** Test data. */
     const TEST_DATA1 = [
-        [ 'a' => '1', 'b' => '1' ],
-        [ 'a' => '5', 'b' => '9' ],
-        [ 'a' => '8', 'b' => '3' ],
-        [ 'a' => '0', 'b' => '2' ],
-        [ 'a' => '0', 'b' => '1' ],
-        [ 'a' => '0', 'b' => '6' ],
+        ['a' => '1', 'b' => '1'],
+        ['a' => '5', 'b' => '9'],
+        ['a' => '8', 'b' => '3'],
+        ['a' => '0', 'b' => '2'],
+        ['a' => '0', 'b' => '1'],
+        ['a' => '0', 'b' => '6'],
     ];
 
     /** Expression config */
@@ -49,12 +48,12 @@ class tool_dataflows_flow_transformer_alter_test extends \advanced_testcase {
 
     /** To be expected. */
     const EXPECTED1 = [
-        [ 'a' => 'o', 'b' => '1', 'c' => '1 1', 'd' => 2 ],
-        [ 'a' => 'o', 'b' => '9', 'c' => '5 9', 'd' => 14 ],
-        [ 'a' => 'o', 'b' => '3', 'c' => '8 3', 'd' => 11 ],
-        [ 'a' => 'o', 'b' => '2', 'c' => '0 2', 'd' => 2 ],
-        [ 'a' => 'o', 'b' => '1', 'c' => '0 1', 'd' => 1 ],
-        [ 'a' => 'o', 'b' => '6', 'c' => '0 6', 'd' => 6 ],
+        ['a' => 'o', 'b' => '1', 'c' => '1 1', 'd' => 2],
+        ['a' => 'o', 'b' => '9', 'c' => '5 9', 'd' => 14],
+        ['a' => 'o', 'b' => '3', 'c' => '8 3', 'd' => 11],
+        ['a' => 'o', 'b' => '2', 'c' => '0 2', 'd' => 2],
+        ['a' => 'o', 'b' => '1', 'c' => '0 1', 'd' => 1],
+        ['a' => 'o', 'b' => '6', 'c' => '0 6', 'd' => 6],
     ];
 
     /** Input file name. */
@@ -63,7 +62,7 @@ class tool_dataflows_flow_transformer_alter_test extends \advanced_testcase {
     /** Output file name. */
     const OUTPUT_FILE_NAME = 'output.json';
 
-    /** @var string  Base directory. */
+    /** @var string Base directory. */
     private $basedir;
 
     /**
@@ -118,9 +117,9 @@ class tool_dataflows_flow_transformer_alter_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function alter_provider(): array {
+    public static function alter_provider(): array {
         return [
-            [ self::TEST_DATA1, self::EXPRESSIONS1, self::EXPECTED1 ],
+            [self::TEST_DATA1, self::EXPRESSIONS1, self::EXPECTED1],
         ];
     }
 
@@ -164,9 +163,7 @@ class tool_dataflows_flow_transformer_alter_test extends \advanced_testcase {
         $alter->name = 'filter';
         $alter->type = $namespace . 'flow_transformer_alter';
         $alter->depends_on([$reader]);
-        $alter->config = Yaml::dump([
-            'expressions' => $exprs
-        ]);
+        $alter->config = Yaml::dump(['expressions' => $exprs]);
         $dataflow->add_step($alter);
 
         $writer = new step();

--- a/tests/tool_dataflows_flow_transformer_filter_test.php
+++ b/tests/tool_dataflows_flow_transformer_filter_test.php
@@ -30,12 +30,12 @@ use tool_dataflows\local\execution\engine;
 class tool_dataflows_flow_transformer_filter_test extends \advanced_testcase {
     /** Test data. */
     const TEST_DATA = [
-        [ 'a' => '1', 'b' => 'a_1_b' ],
-        [ 'a' => '5', 'b' => 'a_9_b' ],
-        [ 'a' => 'x', 'b' => 'a_3_b' ],
-        [ 'a' => '0', 'b' => 'a_2_b' ],
-        [ 'a' => '0', 'b' => 'a_1_b' ],
-        [ 'a' => '0', 'b' => 'a_6_b' ],
+        ['a' => '1', 'b' => 'a_1_b'],
+        ['a' => '5', 'b' => 'a_9_b'],
+        ['a' => 'x', 'b' => 'a_3_b'],
+        ['a' => '0', 'b' => 'a_2_b'],
+        ['a' => '0', 'b' => 'a_1_b'],
+        ['a' => '0', 'b' => 'a_6_b'],
     ];
 
     /** Input file name. */
@@ -44,7 +44,7 @@ class tool_dataflows_flow_transformer_filter_test extends \advanced_testcase {
     /** Output file name. */
     const OUTPUT_FILE_NAME = 'output.json';
 
-    /** @var string  Base directory. */
+    /** @var string Base directory. */
     private $basedir;
 
     /**
@@ -69,7 +69,6 @@ class tool_dataflows_flow_transformer_filter_test extends \advanced_testcase {
     protected function tearDown(): void {
         $this->basedir = null;
     }
-
 
     /**
      * Tests appending to many files, declared 1:1.
@@ -100,21 +99,27 @@ class tool_dataflows_flow_transformer_filter_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function filter_provider() {
+    public static function filter_provider(): array {
         return [
-            [ 'record.a == 1', [
-                [ 'a' => '1', 'b' => 'a_1_b' ],
-            ]],
-            [ "record.a == '0'", [
-                [ 'a' => '0', 'b' => 'a_2_b' ],
-                [ 'a' => '0', 'b' => 'a_1_b' ],
-                [ 'a' => '0', 'b' => 'a_6_b' ],
-            ]],
-            [ "record.b >= 'a_3_b'", [
-                [ 'a' => '5', 'b' => 'a_9_b' ],
-                [ 'a' => 'x', 'b' => 'a_3_b' ],
-                [ 'a' => '0', 'b' => 'a_6_b' ],
-            ]],
+            [
+                'record.a == 1', [
+                    ['a' => '1', 'b' => 'a_1_b'],
+                ],
+            ],
+            [
+                "record.a == '0'", [
+                    ['a' => '0', 'b' => 'a_2_b'],
+                    ['a' => '0', 'b' => 'a_1_b'],
+                    ['a' => '0', 'b' => 'a_6_b'],
+                ],
+            ],
+            [
+                "record.b >= 'a_3_b'", [
+                    ['a' => '5', 'b' => 'a_9_b'],
+                    ['a' => 'x', 'b' => 'a_3_b'],
+                    ['a' => '0', 'b' => 'a_6_b'],
+                ],
+            ],
         ];
     }
 
@@ -157,9 +162,7 @@ class tool_dataflows_flow_transformer_filter_test extends \advanced_testcase {
         $filter->name = 'filter';
         $filter->type = $namespace . 'flow_transformer_filter';
         $filter->depends_on([$reader]);
-        $filter->config = Yaml::dump([
-            'filter' => $expr
-        ]);
+        $filter->config = Yaml::dump(['filter' => $expr]);
         $dataflow->add_step($filter);
 
         $writer = new step();

--- a/tests/tool_dataflows_flow_transformer_regex_test.php
+++ b/tests/tool_dataflows_flow_transformer_regex_test.php
@@ -29,12 +29,11 @@ use tool_dataflows\local\execution\engine;
  */
 class tool_dataflows_flow_transformer_regex_test extends \advanced_testcase {
 
-
     /** Test data. */
     const TEST_DATA = [
-        [ 'test' => 'hello world' ],
-        [ 'test' => 'hello earth' ],
-        [ 'test' => '' ],
+        ['test' => 'hello world'],
+        ['test' => 'hello earth'],
+        ['test' => ''],
     ];
 
     /** Expression config */
@@ -45,9 +44,9 @@ class tool_dataflows_flow_transformer_regex_test extends \advanced_testcase {
 
     /** To be expected. */
     const EXPECTED = [
-        [ 'test' => 'hello world', 'regex' => 'world' ],
-        [ 'test' => 'hello earth', 'regex' => null ],
-        [ 'test' => '', 'regex' => null ],
+        ['test' => 'hello world', 'regex' => 'world'],
+        ['test' => 'hello earth', 'regex' => null],
+        ['test' => '', 'regex' => null],
     ];
 
     /** Input file name. */
@@ -56,7 +55,7 @@ class tool_dataflows_flow_transformer_regex_test extends \advanced_testcase {
     /** Output file name. */
     const OUTPUT_FILE_NAME = 'output.json';
 
-    /** @var string  Base directory. */
+    /** @var string Base directory. */
     private $basedir;
 
     /**
@@ -111,9 +110,9 @@ class tool_dataflows_flow_transformer_regex_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function regex_provider(): array {
+    public static function regex_provider(): array {
         return [
-            [ self::TEST_DATA, self::CONFIG, self::EXPECTED ],
+            [self::TEST_DATA, self::CONFIG, self::EXPECTED],
             [
                 [['test' => '1,2,3,4,5,6,7,8,9']],
                 [

--- a/tests/tool_dataflows_gpg_test.php
+++ b/tests/tool_dataflows_gpg_test.php
@@ -17,7 +17,6 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\step\connector_gpg;
 
 /**
@@ -29,6 +28,7 @@ use tool_dataflows\local\step\connector_gpg;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_gpg_test extends \advanced_testcase {
+
     /**
      * Set up before each test
      */
@@ -61,7 +61,7 @@ class tool_dataflows_gpg_test extends \advanced_testcase {
             Yaml::dump([
                 'dir1' => 'everywhere',
                 'dir2' => '/anywhere',
-                'dir3' => 'sftp://somewhere'
+                'dir3' => 'sftp://somewhere',
             ]),
             'tool_dataflows'
         );
@@ -76,7 +76,7 @@ class tool_dataflows_gpg_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function has_sideeffect_provider(): array {
+    public static function has_sideeffect_provider(): array {
         return [
             ['test.txt', false],
             ['/test.txt', true],

--- a/tests/tool_dataflows_helper_test.php
+++ b/tests/tool_dataflows_helper_test.php
@@ -51,7 +51,7 @@ class tool_dataflows_helper_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function is_relative_provider(): array {
+    public static function is_relative_provider(): array {
         global $CFG;
         return [
             ['one/path', true],
@@ -81,7 +81,7 @@ class tool_dataflows_helper_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function is_scheme_provider(): array {
+    public static function is_scheme_provider(): array {
         return [
             ['file', 'one/path', false],
             ['file', '/one/path', false],
@@ -113,7 +113,7 @@ class tool_dataflows_helper_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function dir_provider(): array {
+    public static function dir_provider(): array {
         global $CFG;
         return [
             ['', []],
@@ -157,7 +157,7 @@ class tool_dataflows_helper_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function path_validate_provider(): array {
+    public static function path_validate_provider(): array {
         return [
             ['one/path', true],
             ['/one/path', false],
@@ -185,7 +185,7 @@ class tool_dataflows_helper_test extends \advanced_testcase {
      *
      * @return \string[][]
      */
-    public function bash_escape_provider(): array {
+    public static function bash_escape_provider(): array {
         return [
             ['', "''"],
             ['something with a space', "'something with a space'"],
@@ -210,7 +210,7 @@ class tool_dataflows_helper_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function extract_http_headers_provider(): array {
+    public static function extract_http_headers_provider(): array {
         return [
             ['', []],
             ['0', false],

--- a/tests/tool_dataflows_json_reader_test.php
+++ b/tests/tool_dataflows_json_reader_test.php
@@ -35,6 +35,7 @@ require_once(dirname(__FILE__) . '/../lib.php');
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_json_reader_test extends \advanced_testcase {
+
     /**
      * Set up before each test
      */
@@ -202,7 +203,7 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
         $sorteduserarray = [
             $this->users[1],
             $this->users[2],
-            $this->users[0]
+            $this->users[0],
         ];
 
         $writer->config = Yaml::dump([
@@ -281,7 +282,7 @@ class tool_dataflows_json_reader_test extends \advanced_testcase {
         $reversesorteduserarray = [
             $this->users[0],
             $this->users[2],
-            $this->users[1]
+            $this->users[1],
         ];
 
         $writer->config = Yaml::dump([

--- a/tests/tool_dataflows_parser_test.php
+++ b/tests/tool_dataflows_parser_test.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows;
 
-
 /**
  * Tests the parser.
  *
@@ -46,7 +45,7 @@ class tool_dataflows_parser_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function find_variable_names_provider(): array {
+    public static function find_variable_names_provider(): array {
         return [
             ['', []],
             ['${{a}}', ['a']],
@@ -79,7 +78,7 @@ class tool_dataflows_parser_test extends \advanced_testcase {
      *
      * @return array of data
      */
-    public function parser_functions_data_provider() {
+    public static function parser_functions_data_provider(): array {
         $example = [
             'a' => [
                 'b' => null,

--- a/tests/tool_dataflows_permitted_dir_test.php
+++ b/tests/tool_dataflows_permitted_dir_test.php
@@ -59,7 +59,7 @@ class tool_dataflows_permitted_dir_test extends \advanced_testcase {
      *
      * @return \string[][]
      */
-    public function valid_data_provider(): array {
+    public static function valid_data_provider(): array {
         return [
             [''],
             ['/* A comment */'],
@@ -91,7 +91,7 @@ class tool_dataflows_permitted_dir_test extends \advanced_testcase {
      *
      * @return \string[][]
      */
-    public function invalid_data_provider(): array {
+    public static function invalid_data_provider(): array {
         return [
             ['/tmp/* A comment', 'path_invalid'],
             ['http://tmp', 'path_invalid'],

--- a/tests/tool_dataflows_remove_file_test.php
+++ b/tests/tool_dataflows_remove_file_test.php
@@ -65,7 +65,7 @@ class tool_dataflows_remove_file_test extends \advanced_testcase {
             Yaml::dump([
                 'dir1' => 'everywhere',
                 'dir2' => '/anywhere',
-                'dir3' => 'sftp://somewhere'
+                'dir3' => 'sftp://somewhere',
             ]),
             'tool_dataflows'
         );
@@ -80,7 +80,7 @@ class tool_dataflows_remove_file_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function has_sideeffect_provider(): array {
+    public static function has_sideeffect_provider(): array {
         return [
             ['test.txt', false],
             ['/test.txt', true],
@@ -138,9 +138,7 @@ class tool_dataflows_remove_file_test extends \advanced_testcase {
         $step = new step();
         $step->name = 'hoover';
         $step->type = connector_remove_file::class;
-        $step->config = Yaml::dump([
-            'file' => $file,
-        ]);
+        $step->config = Yaml::dump(['file' => $file]);
         $dataflow->add_step($step);
 
         return $dataflow;

--- a/tests/tool_dataflows_secret_service_test.php
+++ b/tests/tool_dataflows_secret_service_test.php
@@ -26,11 +26,9 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\application_trait;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\service\secret_service;
 use tool_dataflows\local\step\connector_s3;
-use tool_dataflows\step;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/tool_dataflows_sftp_test.php
+++ b/tests/tool_dataflows_sftp_test.php
@@ -87,7 +87,7 @@ class tool_dataflows_sftp_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function sftp_list_constraints_provider(): array {
+    public static function sftp_list_constraints_provider(): array {
         return [
             [
                 ['relativepath', 'alpha', 0, null, false, '', '*.csv'],
@@ -165,7 +165,7 @@ class tool_dataflows_sftp_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function has_sideeffect_provider(): array {
+    public static function has_sideeffect_provider(): array {
         return [
             ['test.txt', false],
             ['/test.txt', true],

--- a/tests/tool_dataflows_sql_reader_test.php
+++ b/tests/tool_dataflows_sql_reader_test.php
@@ -17,9 +17,7 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\dataflow;
 use tool_dataflows\local\execution\engine;
-use tool_dataflows\step;
 use tool_dataflows\local\step\reader_sql;
 
 defined('MOODLE_INTERNAL') || die();

--- a/tests/tool_dataflows_step_test.php
+++ b/tests/tool_dataflows_step_test.php
@@ -65,7 +65,7 @@ class tool_dataflows_step_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function alias_validation_provider(): array {
+    public static function alias_validation_provider(): array {
         return [
             ['simplename', true],
             ['snake_name', true],
@@ -117,7 +117,7 @@ class tool_dataflows_step_test extends \advanced_testcase {
      *
      * @return \string[][]
      */
-    public function set_name_effects_alias_provider(): array {
+    public static function set_name_effects_alias_provider(): array {
         return [
             ['simplename', 'simplename'],
             ['snake_name', 'snake_name'],

--- a/tests/tool_dataflows_stream_writer_test.php
+++ b/tests/tool_dataflows_stream_writer_test.php
@@ -17,10 +17,8 @@
 namespace tool_dataflows;
 
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\dataflow;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\step\writer_stream;
-use tool_dataflows\step;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -106,7 +104,7 @@ class tool_dataflows_stream_writer_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function data_provider(): array {
+    public static function data_provider(): array {
         return [
             [[['a' => 1, 'b' => 2, 'c' => 3], ['a' => 4, 'b' => 5, 'c' => 6]], false, true],
             [[['a' => 1], ['b' => 5], ['c' => 6]], true, false],

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -18,7 +18,6 @@ namespace tool_dataflows;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\application_trait;
 use tool_dataflows\local\scheduler;
 use tool_dataflows\local\step;
 
@@ -301,7 +300,7 @@ class tool_dataflows_test extends \advanced_testcase {
         $this->assertCount(3, (array) $steps);
 
         // Find the CRON step.
-        $cronstep = current(array_filter((array) $steps, function($step) {
+        $cronstep = current(array_filter((array) $steps, function ($step) {
             return $step->alias == 'cron';
         }));
         $this->assertNotEmpty($cronstep);

--- a/tests/tool_dataflows_upgrade_test.php
+++ b/tests/tool_dataflows_upgrade_test.php
@@ -29,6 +29,7 @@ require_once(__DIR__.'/../db/upgrade.php');
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_dataflows_upgrade_test extends \advanced_testcase {
+
     /**
      * Test config upgrade helper.
      *

--- a/tests/tool_dataflows_variables_new_test.php
+++ b/tests/tool_dataflows_variables_new_test.php
@@ -16,7 +16,6 @@
 
 namespace tool_dataflows;
 
-use tool_dataflows\local\variables\var_value;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -245,7 +244,7 @@ class tool_dataflows_variables_new_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function types_provider() {
+    public static function types_provider(): array {
         $vars = new var_object_for_testing('one');
         $vars->set('d', '${{a}}');
         return [

--- a/tests/tool_dataflows_variables_test.php
+++ b/tests/tool_dataflows_variables_test.php
@@ -18,9 +18,7 @@ namespace tool_dataflows;
 
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\dataflow;
 use tool_dataflows\local\execution\engine;
-use tool_dataflows\step;
 use tool_dataflows\local\execution;
 use tool_dataflows\local\step\connector_curl;
 use tool_dataflows\local\step\connector_debugging;

--- a/tests/tool_dataflows_web_service_flow_test.php
+++ b/tests/tool_dataflows_web_service_flow_test.php
@@ -20,14 +20,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/application_trait.php');
 
-
-
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Yaml\Yaml;
-use tool_dataflows\dataflow;
 use tool_dataflows\local\execution\engine;
 use tool_dataflows\local\step\flow_web_service;
-use tool_dataflows\step;
 
 /**
  * Unit test for the web service flow step.

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024053100;
-$plugin->release = 2024053100;
+$plugin->version = 2024101000;
+$plugin->release = 2024101000;
 $plugin->requires = 2022112800;    // Our lowest supported Moodle (3.3.0).
 $plugin->supported = [400, 402];
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
### Verbosity / min log level setting (per dataflow)

![image](https://github.com/user-attachments/assets/f15945d7-3790-4771-bec1-a6a1aa3930f9)

### Log comparison:

Before:
`[2024-10-10 11:08:57.219433] dataflow/12.WARNING: Log: Example log entry 1 [] [] `
After:
`[2024-10-10 11:08:57.219433] dataflow/12.WARNING: Log: Example log entry 1 {"first":"1","second":"2","third":"3"} [] `


Example test dataflow:
[log_testing_20241010_0254.yml.txt](https://github.com/user-attachments/files/17321158/log_testing_20241010_0254.yml.txt)