### PR TITLE
[#911] fix sql cleaning

### DIFF
--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -48,7 +48,8 @@ class reader_sql extends reader_step {
      */
     public static function form_define_fields(): array {
         return [
-            'sql' => ['type' => PARAM_TEXT, 'required' => true],
+            // Must be PARAM_RAW to avoid clean_param mangling the sql.
+            'sql' => ['type' => PARAM_RAW, 'required' => true],
             'counterfield' => ['type' => PARAM_TEXT],
             'countervalue' => ['type' => PARAM_TEXT],
         ];

--- a/classes/local/step/sql_trait.php
+++ b/classes/local/step/sql_trait.php
@@ -175,7 +175,8 @@ trait sql_trait {
      */
     public static function form_define_fields(): array {
         return [
-            'sql' => ['type' => PARAM_TEXT, 'required' => true],
+            // Must be PARAM_RAW to avoid clean_param mangling the sql.
+            'sql' => ['type' => PARAM_RAW, 'required' => true],
         ];
     }
 


### PR DESCRIPTION
Closes #911 

**Summary**

It was `clean_param` being called when `PARAM_TEXT` that mangles the `<=` in the sql. I checked a similar plugin report_customsql, and it used PARAM_RAW

**Testing**

- Manually tested by putting in the SQL from the issue linked above into step definitions, saved, and confirmed no longer removes the text after the `<=`
- (side note, I attempted to add a unit test for this which appears possible https://moodledev.io/docs/4.5/apis/subsystems/form#unit-testing but I could not get it to work properly and it does not seem worth it to spend any longer)

** Cherry picks**
- https://github.com/catalyst/moodle-tool_dataflows/pull/913