### PR TITLE
issue #931: get rid of local_aws

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       disable_grunt: true
       min_php: 7.4
       extra_plugin_runners: |
-          moodle-plugin-ci add-plugin catalyst/moodle-local_aws --branch ci-for-tool_dataflows;
           sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y graphviz;

--- a/classes/local/step/connector_sns_notify.php
+++ b/classes/local/step/connector_sns_notify.php
@@ -18,6 +18,8 @@ namespace tool_dataflows\local\step;
 
 use Aws\Exception\AwsException;
 
+use \core\aws\client_factory;
+
 /**
  * Amazon SNS event notification step.
  *
@@ -75,15 +77,6 @@ class connector_sns_notify extends connector_step {
     public function execute($input = null) {
         global $CFG;
 
-        try {
-            // Only autoload the AWS SDK at runtime.
-            require_once($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php');
-        } catch (\Exception $e) {
-            // TODO specific exception.
-            $this->enginestep->log->error(get_string('local_aws_missing', 'tool_dataflows'));
-            return false;
-        }
-
         // Do not execute operations during a dry run.
         if ($this->enginestep->engine->isdryrun) {
             $this->enginestep->log->info('Skip SNS notification as this is a dry run.');
@@ -107,7 +100,7 @@ class connector_sns_notify extends connector_step {
         }
 
         try {
-            $snsclient = \local_aws\local\client_factory::get_client('\Aws\Sns\SnsClient', $connectionoptions);
+            $snsclient = client_factory::get_client('\Aws\Sns\SnsClient', $connectionoptions);
         } catch (\Exception $e) {
             // TODO specific exception.
             $this->enginestep->log->error(get_string('s3_configuration_error', 'tool_dataflows'));

--- a/classes/local/step/s3_trait.php
+++ b/classes/local/step/s3_trait.php
@@ -16,6 +16,7 @@
 
 namespace tool_dataflows\local\step;
 
+use core\aws\client_factory;
 use tool_dataflows\helper;
 
 /**
@@ -98,15 +99,6 @@ trait s3_trait {
         global $CFG;
         // Engine step contains the execution context, configuration, variables etc.
 
-        try {
-            // Only autoload the AWS SDK at runtime.
-            require_once($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php');
-        } catch (\Exception $e) {
-            // TODO specific exception.
-            $this->enginestep->log(get_string('local_aws_missing', 'tool_dataflows'));
-            return $input;
-        }
-
         $stepvars = $this->get_variables();
         $config = $stepvars->get('config');
         $connectionoptions = [
@@ -123,7 +115,7 @@ trait s3_trait {
         }
 
         try {
-            $s3client = \local_aws\local\client_factory::get_client('\Aws\S3\S3Client', $connectionoptions);
+            $s3client = client_factory::get_client('\Aws\S3\S3Client', $connectionoptions);
         } catch (\Exception $e) {
             // TODO specific exception.
             $this->enginestep->log(get_string('s3_configuration_error', 'tool_dataflows'));

--- a/lang/en/tool_dataflows.php
+++ b/lang/en/tool_dataflows.php
@@ -285,7 +285,6 @@ $string['config_user_invalid'] = 'User \'{$a}\' is invalid or does not exist.';
 $string['invalid_config'] = 'Invalid configuration';
 $string['non_reader_steps_must_have_flow_upstreams'] = 'Non reader steps must have at least one flow step dependency.';
 $string['format_not_supported'] = 'The format \'{$a}\' is not supported.';
-$string['local_aws_missing'] = 'Failed to load AWS dependencies. Please ensure local_aws is installed.';
 $string['s3_copy_failed'] = 'S3 copy failed. {$a}';
 $string['s3_configuration_error'] = 'S3 client creation failed with provided configuration. Check values are valid.';
 $string['missing_source_file'] = 'Unable to open local file for copying.';

--- a/tests/tool_dataflows_test.php
+++ b/tests/tool_dataflows_test.php
@@ -167,27 +167,6 @@ class tool_dataflows_test extends \advanced_testcase {
     }
 
     /**
-     * Test custom step type based on the callback defined in the manager.
-     *
-     * @runInSeparateProcess
-     * @covers \tool_dataflows\dataflow\manager::get_steps_types
-     */
-    public function test_local_aws_custom_step() {
-        // The test should only run if this condition is true.
-        $localawsexampleclass = class_exists(\local_aws\step\example::class);
-        if (!$localawsexampleclass) {
-            $this->markTestSkipped('local_aws with custom step not located, skipping this specific test.');
-            return;
-        }
-
-        $steptypes = manager::get_steps_types();
-        $classnames = array_map(function ($class) {
-            return get_class($class);
-        }, $steptypes);
-        $this->assertContains(\local_aws\step\example::class, $classnames);
-    }
-
-    /**
      * Tests whether the is_dag graph function is giving the expected output
      *
      * @covers \tool_dataflows\graph::is_dag


### PR DESCRIPTION
We use marked for deprecation method, but HQ may change their mind about that. See some comms in https://tracker.moodle.org/browse/MDL-82459