### PR TITLE
SQL reader step fix undefined property error

### DIFF
--- a/classes/local/step/reader_sql.php
+++ b/classes/local/step/reader_sql.php
@@ -264,10 +264,12 @@ ORDER BY id ASC
         $config = $variables->get('config');
         if (!empty($config->counterfield)) {
             $counterfield = $config->counterfield;
-            $variables->set('config.countervalue', $input->{$counterfield});
-            $this->stepdef->set_config_by_name('countervalue', $input->{$counterfield});
-            if (!$this->is_dry_run()) {
-                $this->stepdef->save();
+            if (isset($input->{$counterfield})) {
+                $variables->set('config.countervalue', $input->{$counterfield});
+                $this->stepdef->set_config_by_name('countervalue', $input->{$counterfield});
+                if (!$this->is_dry_run()) {
+                    $this->stepdef->save();
+                }
             }
         }
 


### PR DESCRIPTION
Hi

Before this patch, the SQL reader flow step is breaking silently such that the data is exposed to the next steps but the error causes the response from the next step from passing on.

**Testing instructions:**

- Create SQL reader step and add 'record' to the field 'Counter field'.
-- Add fields in Extra settings -> User defined variables 
- Add a CURL step and use the data from the above SQL reader
- Click on 'Run now'.
- You will get _php Undefined property: stdClass::$record error_ and the curl step response will not be recorded

Regards,
Sumaiya
