### PR TITLE
downgraded monolog/logger method headers 

### DIFF
--- a/vendor/monolog/monolog/src/Monolog/Logger.php
+++ b/vendor/monolog/monolog/src/Monolog/Logger.php
@@ -558,13 +558,13 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param mixed             $level   The log level (a Monolog, PSR-3 or RFC 5424 level)
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param mixed     $level   The log level (a Monolog, PSR-3 or RFC 5424 level)
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      *
      * @phpstan-param Level|LogLevel::* $level
      */
-    public function log($level, string|\Stringable $message, array $context = []): void
+    public function log($level, $message, array $context = [])
     {
         if (!$level instanceof Level) {
             if (!\is_string($level) && !\is_int($level)) {
@@ -586,10 +586,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function debug(string|\Stringable $message, array $context = []): void
+    public function debug($message, array $context = [])
     {
         $this->addRecord(Level::Debug, (string) $message, $context);
     }
@@ -599,10 +599,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function info(string|\Stringable $message, array $context = []): void
+    public function info($message, array $context = [])
     {
         $this->addRecord(Level::Info, (string) $message, $context);
     }
@@ -612,10 +612,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function notice(string|\Stringable $message, array $context = []): void
+    public function notice($message, array $context = [])
     {
         $this->addRecord(Level::Notice, (string) $message, $context);
     }
@@ -625,10 +625,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function warning(string|\Stringable $message, array $context = []): void
+    public function warning($message, array $context = [])
     {
         $this->addRecord(Level::Warning, (string) $message, $context);
     }
@@ -638,10 +638,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function error(string|\Stringable $message, array $context = []): void
+    public function error($message, array $context = [])
     {
         $this->addRecord(Level::Error, (string) $message, $context);
     }
@@ -651,10 +651,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function critical(string|\Stringable $message, array $context = []): void
+    public function critical($message, array $context = [])
     {
         $this->addRecord(Level::Critical, (string) $message, $context);
     }
@@ -664,10 +664,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function alert(string|\Stringable $message, array $context = []): void
+    public function alert($message, array $context = [])
     {
         $this->addRecord(Level::Alert, (string) $message, $context);
     }
@@ -677,10 +677,10 @@ class Logger implements LoggerInterface, ResettableInterface
      *
      * This method allows for compatibility with common interfaces.
      *
-     * @param string|Stringable $message The log message
-     * @param mixed[]           $context The log context
+     * @param string    $message The log message
+     * @param mixed[]   $context The log context
      */
-    public function emergency(string|\Stringable $message, array $context = []): void
+    public function emergency($message, array $context = [])
     {
         $this->addRecord(Level::Emergency, (string) $message, $context);
     }


### PR DESCRIPTION
to provide compatibility with LoggerInterface.

I assume it is rooted in an older Google abstract Logger class here: https://github.com/moodle/moodle/blob/7d9030acd6e874fd1bb0bd221cb6373e60958aa2/lib/google/src/Google/Logger/Abstract.php#L25

This will fix #989.